### PR TITLE
Prefer SGL setup over PRP when supported

### DIFF
--- a/rom/devs/nvme/nvme_busclass.c
+++ b/rom/devs/nvme/nvme_busclass.c
@@ -82,14 +82,24 @@ static void nvme_iotask(struct nvme_queue *nvmeq)
     SetSignal(0, SIGF_SINGLE);
     for (;;) {
         Wait(SIGF_SINGLE);
-        for (i = 0; i < 16; i ++) {
-            if ((nvmeq->cehandlers[i]) && (nvmeq->cehandlers[i]->ceh_Reply)) {
-                struct IOExtTD *iotd = (struct IOExtTD *)nvmeq->cehandlers[i]->ceh_Msg;
-                nvmeq->cehandlers[i] = NULL;
+        for (i = 0; i < nvmeq->q_depth; i ++) {
+            struct completionevent_handler *slot = nvmeq->cehandlers[i];
+
+            if (slot && slot->ceh_Reply) {
+                struct IOExtTD *iotd = (struct IOExtTD *)slot->ceh_Msg;
 
                 D(bug ("[NVME:Bus] %s: replying to IO @ 0x%p\n", __func__, iotd);)
 
                 ReplyMsg((struct Message *)iotd);
+
+                slot->ceh_Reply = FALSE;
+                slot->ceh_Task = NULL;
+                slot->ceh_Msg = NULL;
+                slot->ceh_SigSet = 0;
+
+                nvmeq->cehandlers[i] = NULL;
+                nvmeq->cehooks[i] = NULL;
+                nvme_release_cmdid(nvmeq, i);
             }
         }
     }
@@ -267,6 +277,8 @@ BOOL Hidd_NVMEBus_Start(OOP_Object *o, struct NVMEBase *NVMEBase)
 
         D(bug ("[NVME:Bus] NVMEBus_Start: buffer @ 0x%p, ExpansionBase @ 0x%p\n", buffer, ExpansionBase);)
 
+        memset(&busehandle, 0, sizeof(busehandle));
+        nvme_dma_init(&busehandle);
         busehandle.ceh_Task = FindTask(NULL);
         busehandle.ceh_SigSet = SIGF_SINGLE;
         OOP_GetAttr(data->ab_Dev->dev_Object, aHidd_PCIDevice_INTLine, &PCIIntLine);
@@ -288,8 +300,12 @@ BOOL Hidd_NVMEBus_Start(OOP_Object *o, struct NVMEBase *NVMEBase)
         D(bug ("[NVME:Bus] NVMEBus_Start: sending nvme_admin_set_features(NVME_FEAT_NUM_QUEUES, %u)\n", c.features.dword11 & 0xFF);)
 
         ULONG signals = SetSignal(0, 0);
-        nvme_submit_admincmd(data->ab_Dev, &c, &busehandle);
-        sigs = nvme_WaitTO(nvmeTimer, 1, 0, busehandle.ceh_SigSet);
+        if (nvme_submit_admincmd(data->ab_Dev, &c, &busehandle) != 0) {
+            sigs = 0;
+            busehandle.ceh_Status = 1;
+        } else {
+            sigs = nvme_WaitTO(nvmeTimer, 1, 0, busehandle.ceh_SigSet);
+        }
         SetSignal(signals, signals);
         if (!(sigs & busehandle.ceh_SigSet)) {
             DIRQ(bug ("[NVME:Bus] NVMEBus_Start: timeout sending set features\n");)
@@ -346,8 +362,6 @@ BOOL Hidd_NVMEBus_Start(OOP_Object *o, struct NVMEBase *NVMEBase)
             if (data->ab_Dev->dev_Queues[nn + 1]) {
                 int flags;
 
-                data->ab_CE = AllocMem(sizeof(struct completionevent_handler) * depth, MEMF_ANY);
-                D(bug ("[NVME:Bus] NVMEBus_Start:  Completion Events @ 0x%p\n", data->ab_CE);)
                 data->ab_Dev->dev_Queues[nn + 1]->q_IOTask =NewCreateTask(TASKTAG_NAME, "NVME Queue IO task",
                         TASKTAG_PC, nvme_iotask,
                         TASKTAG_PRI, 21,
@@ -381,40 +395,43 @@ BOOL Hidd_NVMEBus_Start(OOP_Object *o, struct NVMEBase *NVMEBase)
                     data->ab_Dev->dev_Queues[0]->q_irq = AdminIntLine;
 #endif
 
-                    data->ab_Dev->dev_Queues[nn + 1]->cehooks = AllocMem(sizeof(_NVMEQUEUE_CE_HOOK) * 16, MEMF_CLEAR);
-                    data->ab_Dev->dev_Queues[nn + 1]->cehandlers = AllocMem(sizeof(struct completionevent_handler *) * 16, MEMF_CLEAR);
-
-                    D(bug ("[NVME:Bus] NVMEBus_Start:     hooks @ 0x%p, handlers @ 0x%p\n", data->ab_Dev->dev_Queues[nn + 1]->cehooks, data->ab_Dev->dev_Queues[nn + 1]->cehandlers);)
-
                     /* completion queue needs to be set before the submission queue */
                     flags = NVME_QUEUE_PHYS_CONTIG | NVME_CQ_IRQ_ENABLED;
 
                     memset(&c, 0, sizeof(c));
                     c.create_cq.op.opcode = nvme_admin_create_cq;
-                    c.create_cq.prp1 = AROS_QUAD2LE((UQUAD)(IPTR)data->ab_Dev->dev_Queues[nn + 1]->cqba);
+                    c.create_cq.prp1 = AROS_QUAD2LE(data->ab_Dev->dev_Queues[nn + 1]->cq_dma);
                     c.create_cq.cqid = AROS_WORD2LE(nn + 1);
                     c.create_cq.qsize = AROS_WORD2LE(data->ab_Dev->dev_Queues[nn + 1]->q_depth - 1);
                     c.create_cq.cq_flags = AROS_WORD2LE(flags);
                     c.create_cq.irq_vector = AROS_WORD2LE(nn);
 
                     signals = SetSignal(0, 0);
-                    nvme_submit_admincmd(data->ab_Dev, &c, &busehandle);
-                    sigs = nvme_WaitTO(nvmeTimer, 1, 0, busehandle.ceh_SigSet);
+                    if (nvme_submit_admincmd(data->ab_Dev, &c, &busehandle) != 0) {
+                        sigs = 0;
+                        busehandle.ceh_Status = 1;
+                    } else {
+                        sigs = nvme_WaitTO(nvmeTimer, 1, 0, busehandle.ceh_SigSet);
+                    }
                     SetSignal(signals, signals);
                     if ((sigs & busehandle.ceh_SigSet) &&  (!busehandle.ceh_Status)) {
                         flags = NVME_QUEUE_PHYS_CONTIG | NVME_SQ_PRIO_MEDIUM;
 
                         memset(&c, 0, sizeof(c));
                         c.create_sq.op.opcode = nvme_admin_create_sq;
-                        c.create_sq.prp1 = AROS_QUAD2LE((UQUAD)(IPTR)data->ab_Dev->dev_Queues[nn + 1]->sqba);
+                        c.create_sq.prp1 = AROS_QUAD2LE(data->ab_Dev->dev_Queues[nn + 1]->sq_dma);
                         c.create_sq.sqid = AROS_WORD2LE(nn + 1);
                         c.create_sq.qsize = AROS_WORD2LE(data->ab_Dev->dev_Queues[nn + 1]->q_depth - 1);
                         c.create_sq.sq_flags = AROS_WORD2LE(flags);
                         c.create_sq.cqid = AROS_WORD2LE(nn + 1);
 
                         signals = SetSignal(0, 0);
-                        nvme_submit_admincmd(data->ab_Dev, &c, &busehandle);
-                        sigs = nvme_WaitTO(nvmeTimer, 1, 0, busehandle.ceh_SigSet);
+                        if (nvme_submit_admincmd(data->ab_Dev, &c, &busehandle) != 0) {
+                            sigs = 0;
+                            busehandle.ceh_Status = 1;
+                        } else {
+                            sigs = nvme_WaitTO(nvmeTimer, 1, 0, busehandle.ceh_SigSet);
+                        }
                         SetSignal(signals, signals);
                         if ((sigs & busehandle.ceh_SigSet) &&  (!busehandle.ceh_Status)) {
                             data->ab_Dev->dev_Queues[nn + 1]->q_IntHandler.is_Node.ln_Name = "NVME IO Interrupt";
@@ -429,11 +446,15 @@ BOOL Hidd_NVMEBus_Start(OOP_Object *o, struct NVMEBase *NVMEBase)
                         }
                     } else {
                         bug ("[NVME:Bus] NVMEBus_Start: ERROR - failed to register IO completion queue (status=%u)\n", busehandle.ceh_Status);
+                        nvme_free_queue(data->ab_Dev->dev_Queues[nn + 1]);
+                        data->ab_Dev->dev_Queues[nn + 1] = NULL;
                     }
                 }
 #if defined(USE_MSI)
                 else {
                     bug ("[NVME:Bus] NVMEBus_Start: ERROR - failed to obtain necessary vector attribs\n");
+                    nvme_free_queue(data->ab_Dev->dev_Queues[nn + 1]);
+                    data->ab_Dev->dev_Queues[nn + 1] = NULL;
                 }
 #endif
             } else {
@@ -457,14 +478,18 @@ BOOL Hidd_NVMEBus_Start(OOP_Object *o, struct NVMEBase *NVMEBase)
             memset(buffer, 0, 8192);
             memset(&c, 0, sizeof(c));
             c.identify.op.opcode = nvme_admin_identify;
-            c.identify.prp1 = AROS_QUAD2LE((UQUAD)(IPTR)buffer);
+                    c.identify.prp1 = AROS_QUAD2LE((UQUAD)(IPTR)HIDD_PCIDriver_CPUtoPCI(data->ab_Dev->dev_PCIDriverObject, buffer));
             c.identify.nsid = AROS_LONG2LE(nn + 1);
             c.identify.cns = 0;
 
             D(bug ("[NVME:Bus] NVMEBus_Start: ns#%u sending nvme_admin_identify\n", nn + 1);)
             signals = SetSignal(0, 0);
-            nvme_submit_admincmd(data->ab_Dev, &c, &busehandle);
-            sigs = nvme_WaitTO(nvmeTimer, 1, 0, busehandle.ceh_SigSet);
+            if (nvme_submit_admincmd(data->ab_Dev, &c, &busehandle) != 0) {
+                sigs = 0;
+                busehandle.ceh_Status = 1;
+            } else {
+                sigs = nvme_WaitTO(nvmeTimer, 1, 0, busehandle.ceh_SigSet);
+            }
             SetSignal(signals, signals);
             if ((!busehandle.ceh_Status) && (id_ns->ncap != 0)) {
                 int i, lbaf = id_ns->flbas & 0xf;
@@ -485,14 +510,18 @@ BOOL Hidd_NVMEBus_Start(OOP_Object *o, struct NVMEBase *NVMEBase)
 
                 memset(&c, 0, sizeof(c));
                 c.features.op.opcode = nvme_admin_get_features;
-                c.features.prp1 = AROS_QUAD2LE((UQUAD)(IPTR)rt);
+                c.features.prp1 = AROS_QUAD2LE((UQUAD)(IPTR)HIDD_PCIDriver_CPUtoPCI(data->ab_Dev->dev_PCIDriverObject, rt));
                 c.features.fid = AROS_LONG2LE(NVME_FEAT_LBA_RANGE);
                 c.features.nsid = AROS_LONG2LE(nn + 1);
 
                 D(bug ("[NVME:Bus] NVMEBus_Start: ns#%u sending nvme_admin_get_features\n", nn + 1);)
                 signals = SetSignal(0, 0);
-                nvme_submit_admincmd(data->ab_Dev, &c, &busehandle);
-                sigs = nvme_WaitTO(nvmeTimer, 1, 0, busehandle.ceh_SigSet);
+                if (nvme_submit_admincmd(data->ab_Dev, &c, &busehandle) != 0) {
+                    sigs = 0;
+                    busehandle.ceh_Status = 1;
+                } else {
+                    sigs = nvme_WaitTO(nvmeTimer, 1, 0, busehandle.ceh_SigSet);
+                }
                 SetSignal(signals, signals);
                 if (!busehandle.ceh_Status) {
                     D(

--- a/rom/devs/nvme/nvme_controllerclass.c
+++ b/rom/devs/nvme/nvme_controllerclass.c
@@ -72,6 +72,7 @@ static AROS_INTH1(NVME_ResetHandler, device_t, dev)
 
     memset(&c, 0, sizeof(c));
     memset(&cehandle, 0, sizeof(cehandle));
+    nvme_dma_init(&cehandle);
 
     cehandle.ceh_Task = FindTask(NULL);
     cehandle.ceh_SigSet = SIGF_SINGLE;
@@ -85,15 +86,20 @@ static AROS_INTH1(NVME_ResetHandler, device_t, dev)
     DIRQ(bug ("[NVME:Controller] %s: deleting submission queue\n", __func__);)
     c.delete_queue.op.opcode = nvme_admin_delete_sq;
     c.delete_queue.qid = AROS_WORD2LE(1);
-    nvme_submit_admincmd(dev, &c, &cehandle);
-
-    Wait(cehandle.ceh_SigSet);
+    if (nvme_submit_admincmd(dev, &c, &cehandle) == 0) {
+        Wait(cehandle.ceh_SigSet);
+    } else {
+        cehandle.ceh_Status = 1;
+    }
     if (!cehandle.ceh_Status) {
         DIRQ(bug ("[NVME:Controller] %s: deleting completion queue\n", __func__);)
         c.delete_queue.op.opcode = nvme_admin_delete_cq;
         c.delete_queue.qid = AROS_WORD2LE(1);
-        nvme_submit_admincmd(dev, &c, &cehandle);
-        Wait(cehandle.ceh_SigSet);
+        if (nvme_submit_admincmd(dev, &c, &cehandle) == 0) {
+            Wait(cehandle.ceh_SigSet);
+        } else {
+            cehandle.ceh_Status = 1;
+        }
     }
 #endif
     DIRQ(bug ("[NVME:Controller] %s: disabling controller interrupts\n", __func__);)
@@ -110,8 +116,11 @@ static AROS_INTH1(NVME_ResetHandler, device_t, dev)
         DIRQ(bug ("[NVME:Controller] %s: disabling nvme MSI capability, and\n", __func__);)
 #endif
         DIRQ(bug ("[NVME:Controller] %s: setting queue count to 0\n", __func__);)
-        nvme_submit_admincmd(dev, &c, &cehandle);
-        Wait(cehandle.ceh_SigSet);
+        if (nvme_submit_admincmd(dev, &c, &cehandle) == 0) {
+            Wait(cehandle.ceh_SigSet);
+        } else {
+            cehandle.ceh_Status = 1;
+        }
         if (!cehandle.ceh_Status) {
             DIRQ(bug ("[NVME:Controller] %s: Controller ready for shutdown\n", __func__);)
         }
@@ -189,27 +198,6 @@ OOP_Object *NVME__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
                 UQUAD cap;
                 ULONG sigs, aqa;
 
-                dev->dev_Queues[0]->cehooks = AllocMem(sizeof(_NVMEQUEUE_CE_HOOK) * 16, MEMF_CLEAR);
-                if (!dev->dev_Queues[0]->cehooks) {
-                    FreeMem(dev->dev_Queues, sizeof(APTR) * (KrnGetCPUCount() + 1));
-                    dev->dev_Queues = NULL;
-                    // TODO: dispose the controller object
-                    nvme_CloseTimer(nvmeTimer);
-                    return NULL;
-                }
-                D(bug ("[NVME:Controller] %s:     admin queue hooks @ 0x%p\n", __func__, dev->dev_Queues[0]->cehooks);)
-                dev->dev_Queues[0]->cehandlers = AllocMem(sizeof(struct completionevent_handler *) * 16, MEMF_CLEAR);
-                if (!dev->dev_Queues[0]->cehandlers) {
-                    FreeMem(dev->dev_Queues[0]->cehooks, sizeof(_NVMEQUEUE_CE_HOOK) * 16);
-                    dev->dev_Queues[0]->cehooks = NULL;
-                    FreeMem(dev->dev_Queues, sizeof(APTR) * (KrnGetCPUCount() + 1));
-                    dev->dev_Queues = NULL;
-                    // TODO: dispose the controller object
-                    nvme_CloseTimer(nvmeTimer);
-                    return NULL;
-                }
-                D(bug ("[NVME:Controller] %s:     admin queue handlers @ 0x%p\n", __func__, dev->dev_Queues[0]->cehandlers);)
-
                 aqa = dev->dev_Queues[0]->q_depth - 1;
                 aqa |= aqa << 16;
 
@@ -219,8 +207,8 @@ OOP_Object *NVME__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
 
                 dev->dev_nvmeregbase->cc = 0;
                 dev->dev_nvmeregbase->aqa = aqa;
-                dev->dev_nvmeregbase->asq = (UQUAD)(IPTR)dev->dev_Queues[0]->sqba;
-                dev->dev_nvmeregbase->acq = (UQUAD)(IPTR)dev->dev_Queues[0]->cqba;
+                dev->dev_nvmeregbase->asq = dev->dev_Queues[0]->sq_dma;
+                dev->dev_nvmeregbase->acq = dev->dev_Queues[0]->cq_dma;
 
                 /* parse capabilities ... */
                 cap = dev->dev_nvmeregbase->cap;
@@ -246,10 +234,7 @@ OOP_Object *NVME__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
                 dev->dev_Queues[0]->q_IntHandler.is_Data = dev->dev_Queues[0];
                 if (!HIDD_PCIDriver_AddInterrupt(dev->dev_PCIDriverObject, dev->dev_Object, &dev->dev_Queues[0]->q_IntHandler)) {
                     bug("[NVME:Controller] %s: ERROR - failed to add PCI interrupt handler!\n", __func__);
-                    FreeMem(dev->dev_Queues[0]->cehandlers, sizeof(struct completionevent_handler *) * 16);
-                    dev->dev_Queues[0]->cehandlers= NULL;
-                    FreeMem(dev->dev_Queues[0]->cehooks, sizeof(_NVMEQUEUE_CE_HOOK) * 16);
-                    dev->dev_Queues[0]->cehooks = NULL;
+                    nvme_free_queue(dev->dev_Queues[0]);
                     FreeMem(dev->dev_Queues, sizeof(APTR) * (KrnGetCPUCount() + 1));
                     dev->dev_Queues = NULL;
                     // TODO: dispose the controller object
@@ -262,20 +247,27 @@ OOP_Object *NVME__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
                     struct nvme_id_ctrl *ctrl = (struct nvme_id_ctrl *)buffer;
                     struct completionevent_handler cehandle;
                     struct nvme_command c;
+                    ULONG sglcap;
 
+                    memset(&cehandle, 0, sizeof(cehandle));
+                    nvme_dma_init(&cehandle);
                     cehandle.ceh_Task = FindTask(NULL);
                     cehandle.ceh_SigSet = SIGF_SINGLE;
 
                     memset(&c, 0, sizeof(c));
                     c.identify.op.opcode = nvme_admin_identify;
                     c.identify.nsid = 0;
-                    c.identify.prp1 = (UQUAD)(IPTR)buffer;
+                    c.identify.prp1 = AROS_QUAD2LE((UQUAD)(IPTR)HIDD_PCIDriver_CPUtoPCI(dev->dev_PCIDriverObject, buffer));
                     c.identify.cns = 1;
 
                     D(bug ("[NVME:Controller] %s: sending nvme_admin_identify\n", __func__);)
                     ULONG signals = SetSignal(0, 0);
-                    nvme_submit_admincmd(dev, &c, &cehandle);
-                    sigs = nvme_WaitTO(nvmeTimer, 1, 0, cehandle.ceh_SigSet);
+                    if (nvme_submit_admincmd(dev, &c, &cehandle) != 0) {
+                        sigs = 0;
+                        cehandle.ceh_Status = 1;
+                    } else {
+                        sigs = nvme_WaitTO(nvmeTimer, 1, 0, cehandle.ceh_SigSet);
+                    }
                     SetSignal(signals, signals);
                     if ((sigs & cehandle.ceh_SigSet) && (!cehandle.ceh_Status)) {
                         D(bug ("[NVME:Controller] %s:     Model '%s'\n", __func__, ctrl->mn);)
@@ -285,6 +277,17 @@ OOP_Object *NVME__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
 
                         D(bug ("[NVME:Controller] %s: mdts = %u\n", __func__, ctrl->mdts);)
                         dev->dev_mdts = ctrl->mdts;
+
+                        CopyMem(((UBYTE *)ctrl) + NVME_ID_CTRL_SGLS_OFFSET, &sglcap, sizeof(sglcap));
+                        sglcap = AROS_LE2LONG(sglcap);
+
+                        if (sglcap & NVME_ID_CTRL_SGLS_IO_COMMANDS) {
+                            dev->dev_Features |= NVME_DEVF_SGL_SUPPORTED;
+                            D(bug ("[NVME:Controller] %s: controller advertises SGL support (0x%08lx)\n", __func__, sglcap);)
+                        } else {
+                            dev->dev_Features &= ~NVME_DEVF_SGL_SUPPORTED;
+                            D(bug ("[NVME:Controller] %s: controller lacks SGL support (0x%08lx)\n", __func__, sglcap);)
+                        }
 
                         struct TagItem attrs[] = {
                             {aHidd_Name,                (IPTR)"nvme.device"                             },
@@ -320,7 +323,7 @@ OOP_Object *NVME__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
                     HIDD_PCIDriver_FreePCIMem(dev->dev_PCIDriverObject, buffer);
                 } else {
                     D(bug ("[NVME:Controller] %s: ERROR - failed to create DMA buffer!\n", __func__);)
-                    FreeMem(dev->dev_Queues[0]->cehooks, sizeof(_NVMEQUEUE_CE_HOOK) * 16);
+                    nvme_free_queue(dev->dev_Queues[0]);
                     FreeMem(dev->dev_Queues, sizeof(APTR) * (KrnGetCPUCount() + 1));
                     dev->dev_Queues = NULL;
                     // TODO: dispose the controller object
@@ -328,8 +331,14 @@ OOP_Object *NVME__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot_New *msg)
                 }
             } else {
                 bug("[NVME:Controller] %s: ERROR - failed to create Admin Queue!\n", __func__);
-                FreeMem(dev->dev_Queues, sizeof(APTR) * (KrnGetCPUCount() + 1));
-                dev->dev_Queues = NULL;
+                if (dev->dev_Queues && dev->dev_Queues[0]) {
+                    nvme_free_queue(dev->dev_Queues[0]);
+                    dev->dev_Queues[0] = NULL;
+                }
+                if (dev->dev_Queues) {
+                    FreeMem(dev->dev_Queues, sizeof(APTR) * (KrnGetCPUCount() + 1));
+                    dev->dev_Queues = NULL;
+                }
                 data = NULL;
             }
         } else {
@@ -359,6 +368,17 @@ VOID NVME__Root__Dispose(OOP_Class *cl, OOP_Object *o, OOP_Msg msg)
         if (nvmeNode->ac_Object == o) {
             D(bug ("[NVME:Controller] %s: Destroying Controller Entry @ %p\n", __func__, nvmeNode);)
             Remove(&nvmeNode->ac_Node);
+            if (nvmeNode->ac_dev && nvmeNode->ac_dev->dev_Queues) {
+                ULONG q;
+                for (q = 0; q <= nvmeNode->ac_dev->queuecnt; q++) {
+                    if (nvmeNode->ac_dev->dev_Queues[q]) {
+                        nvme_free_queue(nvmeNode->ac_dev->dev_Queues[q]);
+                        nvmeNode->ac_dev->dev_Queues[q] = NULL;
+                    }
+                }
+                FreeMem(nvmeNode->ac_dev->dev_Queues, sizeof(APTR) * (KrnGetCPUCount() + 1));
+                nvmeNode->ac_dev->dev_Queues = NULL;
+            }
         }
     }
 }

--- a/rom/devs/nvme/nvme_driver_review.md
+++ b/rom/devs/nvme/nvme_driver_review.md
@@ -1,0 +1,97 @@
+# NVMe Driver Review
+
+## Overview
+This document records issues observed while reviewing the current NVMe driver implementation in `rom/devs/nvme`, together with suggestions for improving robustness, performance, and feature coverage (notably scatter/gather list support).
+
+## Findings and Recommendations
+
+### 1. Command identifier handling is hard-coded to 16 entries
+`nvme_alloc_cmdid()` wraps the identifier after 16 commands and the queue setup allocates completion hook storage for only 16 slots, regardless of the actual submission queue depth (the admin queue is created with depth 64 and IO queues follow the controller-reported depth).【F:rom/devs/nvme/nvme_hw.c†L24-L46】【F:rom/devs/nvme/nvme_controllerclass.c†L192-L205】【F:rom/devs/nvme/nvme_busclass.c†L341-L387】 This results in command-id reuse while earlier requests are still outstanding once the queue depth exceeds 16, which can corrupt completions.
+
+*Recommendation:* Size the hook/handler arrays to `nvmeq->q_depth` and treat command identifiers as a ring of that size. Track outstanding entries (e.g. a bitmap or free-list) to avoid reissuing an ID until its completion arrives.
+
+*Implementation sketch:*
+- Extend `struct nvme_queue` (in `nvme_intern.h`) with a dynamically sized bitmap or byte array and maintain a `next_cmdid` cursor.
+- Populate the array from `nvme_alloc_queue()` by allocating `q_depth` slots for hooks, handlers, and optional per-command storage.
+- Rework `nvme_alloc_cmdid()` to scan for a free slot while holding the queue lock, mark it busy, and return `-1` when all slots are in use so callers can back off or wait.
+- Release the slot in `nvme_complete_event()` once the completion handler finishes, ensuring the unlock happens after the hook returns so handler state remains valid.
+
+### 2. Submission queues are not flow-controlled
+`nvme_submit_cmd()` advances the submission tail unconditionally and never checks whether the queue is full or whether the completion head has caught up.【F:rom/devs/nvme/nvme_hw.c†L49-L77】 When the queue fills, the driver will overwrite commands that are still pending, leading to lost or corrupted requests.
+
+*Recommendation:* Track `sq_head`/`sq_tail` modulo the queue depth and block (or fail) when `(tail + 1) % depth == sq_head`. Consider per-queue wait lists so tasks sleep until space is available.
+
+*Implementation sketch:*
+- Record queue occupancy (`outstanding` counter or reuse the command-id bitmap) in `nvme_queue` so the submission path knows how many slots remain.
+- Update `nvme_submit_cmd()` to calculate the next tail entry under the queue lock and bail out (or sleep on a queue-local signal) if the submission queue is full.
+- Have `nvme_complete_event()` signal waiters after freeing a slot so producers blocked on a full queue can resume.
+
+### 3. Excessive interrupt disabling during command submission
+`nvme_alloc_cmdid()` and `nvme_submit_cmd()` wrap their critical sections in `Disable()/Enable()` even though spinlocks are also taken on SMP builds.【F:rom/devs/nvme/nvme_hw.c†L31-L75】 This globally masks interrupts, hurting latency and scalability.
+
+*Recommendation:* Use the spinlock alone on SMP and rely on per-queue locking on UP. If interrupt masking is truly needed, use `Forbid()/Permit()` scoped to the queue instead of disabling all interrupts.
+
+*Implementation sketch:*
+- Introduce helper macros that acquire `nvmeq->q_lock` when SMP is enabled and fall back to `Forbid()/Permit()` elsewhere.
+- Replace the `Disable()/Enable()` pairs in `nvme_alloc_cmdid()` and `nvme_submit_cmd()` with the new helpers so interrupts remain enabled during critical sections.
+- Audit other hot paths (e.g. completion processing) to ensure they use the same synchronization primitives for consistency.
+
+### 4. PRP construction violates NVMe rules and uses virtual addresses
+`nvme_initprp()` derives PRP entries from the request’s virtual address and permits non-zero offsets in PRP2 (and subsequent list entries), despite the specification requiring page-aligned physical addresses for every entry after PRP1.【F:rom/devs/nvme/nvme_prp.c†L58-L149】 Because the driver never translates to physical addresses (nor accounts for IOMMUs), controllers will DMA to meaningless locations. Additionally, the optional PRP list is allocated with `AllocMem()`, which does not guarantee DMA-accessible memory.
+
+*Recommendation:* Obtain DMA mappings for the buffer (e.g. via PCI HIDD DMA helpers) and write physical addresses into PRP entries. For two-page transfers, force PRP2 to the start of the second page (offset zero). When a PRP list is needed, allocate it from PCI-visible memory and keep it cache coherent.
+
+*Implementation sketch:*
+- Use the PCI HIDD DMA helper (`HIDD_PCIDriver_MapVirtual()` / `pciGetPhysical()` equivalent) to translate the Exec buffer into physical page addresses before filling PRP fields.
+- Round PRP2 and subsequent list entries down to the nearest page boundary; keep the byte offset exclusively in PRP1 as mandated by the specification.
+- Allocate PRP list pages from PCI-visible memory (for example via `HIDD_PCIDriver_AllocPCIMem()`), store their physical addresses in PRP2, and perform `CachePreDMA()/CachePostDMA()` on both the list and payload buffers.
+
+### 5. Completion bookkeeping copies handlers instead of referencing them
+`nvme_submit_iocmd()` copies the caller-provided handler structure into a per-ID array and then points `cehandlers[cmdid]` back to that array slot.【F:rom/devs/nvme/nvme_queue_io.c†L96-L110】 Because the array is shared and only 16 entries deep, concurrent operations can clobber handler state and the driver never records ownership for more than 16 outstanding commands.
+
+*Recommendation:* Keep a single `completionevent_handler` per outstanding command (again sized to the queue depth) and fill it in place without extra copies.
+
+*Implementation sketch:*
+- Embed a per-command `completionevent_handler` array inside each queue (allocated in `nvme_alloc_queue()`).
+- Adjust `nvme_submit_iocmd()` so it copies the caller's handler into the queue-owned slot (`cmdid` index) and simply stores a pointer to that slot in `cehandlers`.
+- Update the completion path to clear the slot (and release any DMA bounce buffers) before marking the command-id free.
+
+### 6. Missing memory ordering for doorbell writes
+No memory barrier is placed between copying the command to the submission queue and ringing the doorbell.【F:rom/devs/nvme/nvme_hw.c†L65-L70】 On weakly ordered architectures the controller might see the doorbell update before the command contents become visible.
+
+*Recommendation:* Insert a write memory barrier (`MemoryBarrier()`, `KrnStoreFence()`, etc.) before writing the doorbell register.
+
+*Implementation sketch:*
+- Drop a compiler- and architecture-friendly store fence (`__sync_synchronize()` or `AROS_MEMORY_BARRIER()`) right after the `CopyMem()` into the submission queue but before updating the tail doorbell.
+- Wrap the barrier in a helper macro in `nvme_hw.h` so other call sites (e.g. admin queue submissions) can reuse it if needed.
+
+### 7. Scatter/gather support is stubbed out
+`nvme_initsgl()` is unimplemented and always fails, forcing every transfer to be physically contiguous in memory and limiting usable IO sizes.【F:rom/devs/nvme/nvme_sgl.c†L43-L46】 Since `nvme_sector_rw()` does not fall back when SGL setup fails, multi-segment buffers currently cause `IOERR_BADADDRESS`.
+
+*Recommendation:* Implement `nvme_initsgl()` by walking the Exec scatter/gather structures (or building them from `struct MemList`) and emitting a chain of SGL descriptors. Wire it into `nvme_sector_rw()` so the driver chooses between PRP and SGL based on controller capabilities and buffer layout.
+
+*Implementation sketch:*
+- Detect whether `io_Data` references a flat buffer or a `struct MemList`; fall back to PRPs for the former when the transfer fits within MDTS and page alignment allows.
+- Teach `nvme_initsgl()` to iterate over the Exec scatter/gather list, map each segment to a physical address, and emit either keyed-data or unkeyed SGL descriptors in a queue-owned DMA buffer.
+- Extend `nvme_sector_rw()` so it first attempts PRP setup, then calls `nvme_initsgl()` when PRPs are unsuitable (non-contiguous physical pages or transfers exceeding MDTS) and frees the SGL DMA buffer in the completion hook.
+
+### 8. Resource management gaps
+The driver allocates a fresh PRP list buffer for every request that straddles three or more pages and frees it on completion.【F:rom/devs/nvme/nvme_prp.c†L95-L149】【F:rom/devs/nvme/nvme_queue_io.c†L69-L79】 This introduces significant allocation overhead in the IO path.
+
+*Recommendation:* Maintain per-queue DMA pools for PRP/SGL lists to avoid repeated allocations, and consider reusing command structures for better cache locality.
+
+*Implementation sketch:*
+- Create per-queue caches (e.g. small Exec pools) for PRP list pages and SGL descriptor blocks sized to the queue depth.
+- Hand out descriptors from the pool in the submission path and return them in the completion handler, falling back to `AllocMem()` only when the pool is temporarily exhausted.
+- Keep frequently reused command templates (identify, flush, etc.) in queue-local storage so I/O hot paths avoid repeated `memset()` calls.
+
+## Scatter/Gather Enablement Outline
+1. Detect controller support via the Identify data and the optional command set fields (SGLS bit). Wire this into feature negotiation during controller bring-up.
+2. Teach `nvme_sector_rw()` to select PRP vs. SGL dynamically. Attempt PRP first when the buffer is naturally contiguous and falls within MDTS. Fall back to SGL for non-contiguous buffers or very large transfers.
+3. Implement `nvme_initsgl()` to translate the OS scatter/gather representation into NVMe SGL descriptors, ensuring descriptor chains obey controller alignment and length limits. Use DMA-safe allocations and cache maintenance similar to the PRP path.
+4. Update completion handling to release any SGL list storage alongside the current PRP clean-up.
+
+## Additional Ideas
+- Add structured error logging for NVMe status codes (e.g. decode SCT/SC in `nvme_complete_ioevent()` and emit them through `bug()` or a device-specific logger) and plumb the decoded result into extended IO error values so callers can react programmatically.
+- Wire up asynchronous completion polling and distribute queue interrupts across CPUs by enabling MSI-X vector affinity, allowing the queue tasks created in `nvme_busclass.c` to process completions on the CPU that submitted the I/O.
+

--- a/rom/devs/nvme/nvme_hw.h
+++ b/rom/devs/nvme/nvme_hw.h
@@ -1,5 +1,7 @@
 
 extern int nvme_submit_cmd(struct nvme_queue *, struct nvme_command *);
 extern struct nvme_queue *nvme_alloc_queue(device_t, int, int, int);
+extern void nvme_free_queue(struct nvme_queue *);
 extern void nvme_process_cq(struct nvme_queue *);
 extern int nvme_alloc_cmdid(struct nvme_queue *);
+extern void nvme_release_cmdid(struct nvme_queue *, UWORD);

--- a/rom/devs/nvme/nvme_init.c
+++ b/rom/devs/nvme/nvme_init.c
@@ -240,6 +240,7 @@ AROS_UFH3(void, nvme_PCIEnumerator_h,
     if (dev == NULL)
         return;
 
+    memset(dev, 0, sizeof(*dev));
     dev->dev_NVMEBase = NVMEBase;
     dev->dev_Object   = Device;
     dev->dev_HostID   = NVMEBase->nvme_HostCount;

--- a/rom/devs/nvme/nvme_intern.h
+++ b/rom/devs/nvme/nvme_intern.h
@@ -32,6 +32,9 @@
 #define Unit(io) ((struct nvme_Unit *)(io)->io_Unit)
 #define IOStdReq(io) ((struct IOStdReq *)io)
 
+#define NVME_ID_CTRL_SGLS_OFFSET      536
+#define NVME_ID_CTRL_SGLS_IO_COMMANDS (1UL << 0)
+
 /* nvme.device base */
 struct NVMEBase
 {
@@ -139,6 +142,7 @@ typedef struct {
     ULONG              	dev_HostID;
 
     UBYTE               dev_mdts;
+    ULONG               dev_Features;
 
     int                 db_stride;
     volatile struct nvme_registers *dev_nvmeregbase;
@@ -151,6 +155,17 @@ typedef struct {
     struct nvme_queue   **dev_Queues;
 } *device_t;
 
+#define NVME_INLINE_DMA_SEGMENTS   4
+
+#define NVME_DEVF_SGL_SUPPORTED   (1UL << 0)
+
+struct nvme_dma_segment
+{
+    APTR                nds_Address;
+    ULONG               nds_Length;
+    ULONG               nds_Flags;
+};
+
 struct completionevent_handler
 {
     struct Task         *ceh_Task;
@@ -160,7 +175,105 @@ struct completionevent_handler
     ULONG               ceh_Result;
     volatile UWORD      ceh_Status;
     UWORD               ceh_Reply;
+
+    struct nvme_dma_segment ceh_DMAInline[NVME_INLINE_DMA_SEGMENTS];
+    struct nvme_dma_segment *ceh_DMAMap;
+    ULONG               ceh_DMAMapCount;
+    ULONG               ceh_DMAMapCapacity;
 };
+
+static inline void nvme_dma_init(struct completionevent_handler *handler)
+{
+    handler->ceh_DMAMap = handler->ceh_DMAInline;
+    handler->ceh_DMAMapCount = 0;
+    handler->ceh_DMAMapCapacity = NVME_INLINE_DMA_SEGMENTS;
+}
+
+static inline void nvme_dma_reset(struct completionevent_handler *handler)
+{
+    if (handler->ceh_DMAMap && handler->ceh_DMAMap != handler->ceh_DMAInline) {
+        FreeMem(handler->ceh_DMAMap,
+                handler->ceh_DMAMapCapacity * sizeof(struct nvme_dma_segment));
+    }
+    handler->ceh_DMAMap = handler->ceh_DMAInline;
+    handler->ceh_DMAMapCapacity = NVME_INLINE_DMA_SEGMENTS;
+    handler->ceh_DMAMapCount = 0;
+}
+
+static inline BOOL nvme_dma_ensure_capacity(struct completionevent_handler *handler,
+                                            ULONG needed)
+{
+    if (needed <= handler->ceh_DMAMapCapacity) {
+        return TRUE;
+    }
+
+    ULONG new_capacity = handler->ceh_DMAMapCapacity ? handler->ceh_DMAMapCapacity : NVME_INLINE_DMA_SEGMENTS;
+
+    while (new_capacity < needed) {
+        new_capacity <<= 1;
+    }
+
+    struct nvme_dma_segment *new_map = AllocMem(new_capacity * sizeof(struct nvme_dma_segment), MEMF_ANY | MEMF_CLEAR);
+    if (!new_map) {
+        return FALSE;
+    }
+
+    if (handler->ceh_DMAMapCount) {
+        CopyMem(handler->ceh_DMAMap, new_map,
+                handler->ceh_DMAMapCount * sizeof(struct nvme_dma_segment));
+    }
+
+    if (handler->ceh_DMAMap && handler->ceh_DMAMap != handler->ceh_DMAInline) {
+        ULONG old_capacity = handler->ceh_DMAMapCapacity;
+        FreeMem(handler->ceh_DMAMap,
+                old_capacity * sizeof(struct nvme_dma_segment));
+    }
+
+    handler->ceh_DMAMap = new_map;
+    handler->ceh_DMAMapCapacity = new_capacity;
+    return TRUE;
+}
+
+static inline BOOL nvme_dma_append(struct completionevent_handler *handler,
+                                   APTR address, ULONG length, ULONG flags)
+{
+    if (!nvme_dma_ensure_capacity(handler, handler->ceh_DMAMapCount + 1)) {
+        return FALSE;
+    }
+
+    struct nvme_dma_segment *segment = &handler->ceh_DMAMap[handler->ceh_DMAMapCount++];
+    segment->nds_Address = address;
+    segment->nds_Length = length;
+    segment->nds_Flags = flags;
+    return TRUE;
+}
+
+static inline void nvme_dma_release(struct completionevent_handler *handler, BOOL do_post)
+{
+    if (do_post) {
+        ULONG idx;
+
+        for (idx = 0; idx < handler->ceh_DMAMapCount; idx++) {
+            struct nvme_dma_segment *segment = &handler->ceh_DMAMap[idx];
+
+            if (segment->nds_Address && segment->nds_Length) {
+                ULONG length = segment->nds_Length;
+                ULONG postflags = (segment->nds_Flags & DMAFLAGS_PREWRITE) ? DMAFLAGS_POSTWRITE : DMAFLAGS_POSTREAD;
+
+                CachePostDMA(segment->nds_Address, &length, postflags);
+            }
+        }
+    }
+
+    if (handler->ceh_DMAMap && handler->ceh_DMAMap != handler->ceh_DMAInline) {
+        ULONG allocated = handler->ceh_DMAMapCapacity;
+        FreeMem(handler->ceh_DMAMap, allocated * sizeof(struct nvme_dma_segment));
+    }
+
+    handler->ceh_DMAMap = handler->ceh_DMAInline;
+    handler->ceh_DMAMapCapacity = NVME_INLINE_DMA_SEGMENTS;
+    handler->ceh_DMAMapCount = 0;
+}
 
 typedef void (*_NVMEQUEUE_CE_HOOK)(struct nvme_queue *, struct nvme_completion *);
 struct nvme_queue {
@@ -177,15 +290,19 @@ struct nvme_queue {
     UWORD q_irq;
     /* command queue */
     struct nvme_command *sqba;
+    UQUAD sq_dma;
     UWORD sq_head;
     UWORD sq_tail;
     /* completion queue */
     _NVMEQUEUE_CE_HOOK *cehooks;
     struct completionevent_handler **cehandlers;
+    struct completionevent_handler *ce_entries;
     volatile struct nvme_completion *cqba;
+    UQUAD cq_dma;
     UWORD cq_head;
     UWORD cq_phase;
-    unsigned long cmdid_data;//[];
+    UWORD cmdid_hint;
+    UBYTE *cmdid_busy;
 };
 
 struct nvme_Controller
@@ -204,7 +321,6 @@ struct nvme_Bus
     struct NVMEBase     *ab_Base;   /* device self */
     device_t            ab_Dev;
 
-    struct completionevent_handler *ab_CE;
     UWORD               ab_UnitMax;             /* Max units the bus can have   */
     UWORD               ab_UnitCnt;             /* actual # of units on the bus */
     OOP_Object          **ab_Units;

--- a/rom/devs/nvme/nvme_io.c
+++ b/rom/devs/nvme/nvme_io.c
@@ -40,18 +40,21 @@
 #include LC_LIBDEFS_FILE
 
 extern BOOL nvme_initprp(struct nvme_command *cmdio, struct completionevent_handler *ioehandle, struct nvme_Unit *unit, ULONG len, APTR *data, BOOL is_write);
+extern BOOL nvme_initsgl(struct nvme_command *cmdio, struct completionevent_handler *ioehandle, struct nvme_Unit *unit, ULONG len, APTR *data, BOOL is_write);
 
 static BOOL nvme_sector_rw(struct IORequest *io, UQUAD off64, BOOL is_write)
 {
     struct IOExtTD *iotd = (struct IOExtTD *)io;
     struct nvme_Unit *unit = (struct nvme_Unit *)io->io_Unit;
     struct NVMEBase *NVMEBase = unit->au_Bus->ab_Base;
+    device_t dev = unit->au_Bus->ab_Dev;
     APTR data = iotd->iotd_Req.io_Data;
     ULONG len = iotd->iotd_Req.io_Length;
     struct nvme_queue *nvmeq;
     struct completionevent_handler ioehandle;
     struct nvme_command cmdio;
     int queueno;
+    BOOL setup_ok = FALSE;
 
     D(
         bug("[NVME%02ld] %s(%08x%08x, 0x%p, %u) %s\n", unit->au_UnitNum, __func__, (off64 >> 32), off64 & 0xFFFFFFFF, data, len, is_write ? "WRITE" : "READ");
@@ -73,10 +76,26 @@ static BOOL nvme_sector_rw(struct IORequest *io, UQUAD off64, BOOL is_write)
     }
 
     memset(&cmdio, 0, sizeof(cmdio));
-    ioehandle.ceh_IOMem.me_Un.meu_Addr = NULL;
-    if (!nvme_initprp(&cmdio, &ioehandle, unit, len, &data, is_write)) {
-        io->io_Error = IOERR_BADADDRESS;
-        return TRUE;
+    memset(&ioehandle, 0, sizeof(ioehandle));
+    nvme_dma_init(&ioehandle);
+
+    if (dev && (dev->dev_Features & NVME_DEVF_SGL_SUPPORTED)) {
+        if (nvme_initsgl(&cmdio, &ioehandle, unit, len, &data, is_write)) {
+            setup_ok = TRUE;
+        } else {
+            nvme_dma_release(&ioehandle, TRUE);
+            nvme_dma_init(&ioehandle);
+            ioehandle.ceh_IOMem.me_Un.meu_Addr = NULL;
+            ioehandle.ceh_IOMem.me_Length = 0;
+        }
+    }
+
+    if (!setup_ok) {
+        if (!nvme_initprp(&cmdio, &ioehandle, unit, len, &data, is_write)) {
+            nvme_dma_release(&ioehandle, TRUE);
+            io->io_Error = IOERR_BADADDRESS;
+            return TRUE;
+        }
     }
 
     ULONG nsid = (unit->au_UnitNum & ((1 << 12) - 1)) + 1;
@@ -109,8 +128,15 @@ static BOOL nvme_sector_rw(struct IORequest *io, UQUAD off64, BOOL is_write)
         bug("[NVME%02ld(%02u)] %s: %08x%08x (%u)\n", unit->au_UnitNum, queueno, __func__, (cmdio.rw.slba >> 32), (cmdio.rw.slba & 0xFFFFFFFF), AROS_LE2WORD(cmdio.rw.length));
     )
 
-    CachePreDMA(data, &len, is_write ? DMAFLAGS_PREWRITE : DMAFLAGS_PREREAD);
-    nvme_submit_iocmd(unit->au_Bus->ab_CE, nvmeq, &cmdio, &ioehandle);
+    if (nvme_submit_iocmd(nvmeq, &cmdio, &ioehandle) != 0) {
+        if (ioehandle.ceh_IOMem.me_Un.meu_Addr) {
+            FreeMem(ioehandle.ceh_IOMem.me_Un.meu_Addr, ioehandle.ceh_IOMem.me_Length);
+            ioehandle.ceh_IOMem.me_Un.meu_Addr = NULL;
+        }
+        nvme_dma_release(&ioehandle, TRUE);
+        io->io_Error = IOERR_ABORTED;
+        return TRUE;
+    }
 
     return FALSE;
 }

--- a/rom/devs/nvme/nvme_queue.c
+++ b/rom/devs/nvme/nvme_queue.c
@@ -6,7 +6,6 @@
 
 #include <asm/io.h>
 #include <hidd/pci.h>
-#include <interface/Hidd_PCIDriver.h>
 
 #include <string.h>
 
@@ -24,40 +23,134 @@
 
 struct nvme_queue *nvme_alloc_queue(device_t dev, int qid, int depth, int vector)
 {
-    struct NVMEBase *NVMEBase = dev->dev_NVMEBase;;
-    unsigned extra = 0; //DIV_ROUND_UP(depth, 8) + (depth *
-    //      sizeof(struct nvme_cmd_info));
     struct nvme_queue *nvmeq;
+    size_t cq_bytes = depth * sizeof(struct nvme_completion);
+    size_t sq_bytes = depth * sizeof(struct nvme_command);
+    struct NVMEBase *NVMEBase = dev ? dev->dev_NVMEBase : NULL;
 
     D(bug ("[NVME:QUEUE] %s(0x%p, %u, %u, %d)\n", __func__, dev, qid, depth, vector);)
 
-    nvmeq = AllocMem(sizeof(struct nvme_queue) + extra, MEMF_CLEAR);
-    D(bug ("[NVME:QUEUE] %s: queue allocated @ 0x%p (depth %u)\n", __func__, nvmeq, depth);)
-    if (nvmeq) {
-        /* completion queue ... */
-        nvmeq->cqba = HIDD_PCIDriver_AllocPCIMem(dev->dev_PCIDriverObject, depth * sizeof(struct nvme_completion));
-        D(bug ("[NVME:QUEUE] %s:       completion @ 0x%p\n", __func__, nvmeq->cqba);)
-        if (nvmeq->cqba) {
-            memset((void *)nvmeq->cqba, 0, depth * sizeof(struct nvme_completion));
+    if (!dev || !dev->dev_PCIDriverObject || !NVMEBase) {
+        return NULL;
+    }
 
-            /* submission queue ... */
-            nvmeq->sqba = HIDD_PCIDriver_AllocPCIMem(dev->dev_PCIDriverObject, depth * sizeof(struct nvme_command));
-            D(bug ("[NVME:QUEUE] %s:       cmd submission @ 0x%p\n", __func__, nvmeq->sqba);)
-            if (nvmeq->sqba) {
-                nvmeq->dev = dev;
+    (void)NVMEBase;
+
+    nvmeq = AllocMem(sizeof(*nvmeq), MEMF_CLEAR);
+    if (!nvmeq) {
+        return NULL;
+    }
+
+    nvmeq->dev = dev;
+    nvmeq->q_depth = depth;
+    nvmeq->cq_vector = vector;
+    nvmeq->q_db = &dev->dbs[qid << (dev->db_stride + 1)];
 
 #if defined(__AROSEXEC_SMP__)
-                KrnSpinInit(&nvmeq->q_lock);
+    KrnSpinInit(&nvmeq->q_lock);
 #endif
-                nvmeq->cq_head = 0;
-                nvmeq->cq_phase = 1;
 
-                nvmeq->q_db = &dev->dbs[qid << (dev->db_stride + 1)];
-                nvmeq->q_depth = depth;
-                D(bug ("[NVME:QUEUE] %s:       doorbells @ 0x%p\n", __func__, nvmeq->q_db);)
-                nvmeq->cq_vector = vector;
-            }
-        }
+    nvmeq->cmdid_busy = AllocMem(depth, MEMF_CLEAR);
+    if (!nvmeq->cmdid_busy) {
+        nvme_free_queue(nvmeq);
+        return NULL;
     }
+
+    nvmeq->cehooks = AllocMem(sizeof(_NVMEQUEUE_CE_HOOK) * depth, MEMF_CLEAR);
+    if (!nvmeq->cehooks) {
+        nvme_free_queue(nvmeq);
+        return NULL;
+    }
+
+    nvmeq->cehandlers = AllocMem(sizeof(struct completionevent_handler *) * depth, MEMF_CLEAR);
+    if (!nvmeq->cehandlers) {
+        nvme_free_queue(nvmeq);
+        return NULL;
+    }
+
+    nvmeq->ce_entries = AllocMem(sizeof(struct completionevent_handler) * depth, MEMF_CLEAR);
+    if (!nvmeq->ce_entries) {
+        nvme_free_queue(nvmeq);
+        return NULL;
+    }
+
+    nvmeq->cqba = HIDD_PCIDriver_AllocPCIMem(dev->dev_PCIDriverObject, cq_bytes);
+    if (!nvmeq->cqba) {
+        nvme_free_queue(nvmeq);
+        return NULL;
+    }
+    memset((void *)nvmeq->cqba, 0, cq_bytes);
+    nvmeq->cq_dma = (UQUAD)(IPTR)HIDD_PCIDriver_CPUtoPCI(dev->dev_PCIDriverObject, (APTR)nvmeq->cqba);
+
+    nvmeq->sqba = HIDD_PCIDriver_AllocPCIMem(dev->dev_PCIDriverObject, sq_bytes);
+    if (!nvmeq->sqba) {
+        nvme_free_queue(nvmeq);
+        return NULL;
+    }
+    memset(nvmeq->sqba, 0, sq_bytes);
+    nvmeq->sq_dma = (UQUAD)(IPTR)HIDD_PCIDriver_CPUtoPCI(dev->dev_PCIDriverObject, (APTR)nvmeq->sqba);
+
+    nvmeq->cq_head = 0;
+    nvmeq->cq_phase = 1;
+    nvmeq->cmdid_hint = 0;
+
+    D(bug ("[NVME:QUEUE] %s: queue allocated @ 0x%p (depth %u)\n", __func__, nvmeq, depth);)
+    D(bug ("[NVME:QUEUE] %s:       doorbells @ 0x%p\n", __func__, nvmeq->q_db);)
+    D(bug ("[NVME:QUEUE] %s:       completion @ 0x%p (dma %p)\n", __func__, nvmeq->cqba, (APTR)nvmeq->cq_dma);)
+    D(bug ("[NVME:QUEUE] %s:       submission @ 0x%p (dma %p)\n", __func__, nvmeq->sqba, (APTR)nvmeq->sq_dma);)
+
     return nvmeq;
+}
+
+void nvme_free_queue(struct nvme_queue *nvmeq)
+{
+    struct NVMEBase *NVMEBase = (nvmeq && nvmeq->dev) ? nvmeq->dev->dev_NVMEBase : NULL;
+
+    if (!nvmeq) {
+        return;
+    }
+
+    (void)NVMEBase;
+
+    if (nvmeq->sqba) {
+        if (nvmeq->dev && nvmeq->dev->dev_PCIDriverObject && NVMEBase) {
+            HIDD_PCIDriver_FreePCIMem(nvmeq->dev->dev_PCIDriverObject, nvmeq->sqba);
+        }
+        nvmeq->sqba = NULL;
+    }
+
+    if (nvmeq->cqba) {
+        if (nvmeq->dev && nvmeq->dev->dev_PCIDriverObject && NVMEBase) {
+            HIDD_PCIDriver_FreePCIMem(nvmeq->dev->dev_PCIDriverObject, (APTR)nvmeq->cqba);
+        }
+        nvmeq->cqba = NULL;
+    }
+
+    if (nvmeq->ce_entries) {
+        UWORD idx;
+
+        for (idx = 0; idx < nvmeq->q_depth; idx++) {
+            nvme_dma_release(&nvmeq->ce_entries[idx], FALSE);
+        }
+
+        FreeMem(nvmeq->ce_entries, sizeof(struct completionevent_handler) * nvmeq->q_depth);
+        nvmeq->ce_entries = NULL;
+    }
+
+    if (nvmeq->cehandlers) {
+        FreeMem(nvmeq->cehandlers, sizeof(struct completionevent_handler *) * nvmeq->q_depth);
+        nvmeq->cehandlers = NULL;
+    }
+
+    if (nvmeq->cehooks) {
+        FreeMem(nvmeq->cehooks, sizeof(_NVMEQUEUE_CE_HOOK) * nvmeq->q_depth);
+        nvmeq->cehooks = NULL;
+    }
+
+    if (nvmeq->cmdid_busy) {
+        FreeMem(nvmeq->cmdid_busy, nvmeq->q_depth);
+        nvmeq->cmdid_busy = NULL;
+    }
+
+    FreeMem(nvmeq, sizeof(*nvmeq));
 }

--- a/rom/devs/nvme/nvme_queue.h
+++ b/rom/devs/nvme/nvme_queue.h
@@ -1,2 +1,3 @@
 
 struct nvme_queue *nvme_alloc_queue(device_t dev, int qid, int depth, int vector);
+void nvme_free_queue(struct nvme_queue *nvmeq);

--- a/rom/devs/nvme/nvme_queue_admin.c
+++ b/rom/devs/nvme/nvme_queue_admin.c
@@ -6,7 +6,6 @@
 
 #include <asm/io.h>
 #include <hidd/pci.h>
-#include <interface/Hidd_PCIDriver.h>
 
 #include <string.h>
 
@@ -33,21 +32,30 @@ void nvme_complete_adminevent(struct nvme_queue *nvmeq, struct nvme_completion *
         handler->ceh_Result = AROS_LE2LONG(cqe->result);
         handler->ceh_Status = AROS_LE2WORD(cqe->status) >> 1;
         nvmeq->cehandlers[cqe->command_id] = NULL;
+        nvme_dma_release(handler, TRUE);
         D(bug ("[NVME:ADMINQ] %s: Signaling 0x%p (%08x)\n", __func__, handler->ceh_Task, handler->ceh_SigSet);)
         Signal(handler->ceh_Task, handler->ceh_SigSet);
+        nvmeq->cehooks[cqe->command_id] = NULL;
+        nvme_release_cmdid(nvmeq, cqe->command_id);
     }
 }
 
 int nvme_submit_admincmd(device_t dev, struct nvme_command *cmd, struct completionevent_handler *handler)
 {
     int retval;
+    int cmdid;
 
     D(bug("[NVME:ADMINQ] %s(0x%p, 0x%p)\n", __func__, dev, cmd);)
 
-    cmd->common.op.command_id = nvme_alloc_cmdid(dev->dev_Queues[0]);
+    cmdid = nvme_alloc_cmdid(dev->dev_Queues[0]);
+    if (cmdid < 0) {
+        return -1;
+    }
 
-    dev->dev_Queues[0]->cehooks[cmd->common.op.command_id] = nvme_complete_adminevent;
-    dev->dev_Queues[0]->cehandlers[cmd->common.op.command_id] = handler;
+    cmd->common.op.command_id = cmdid;
+
+    dev->dev_Queues[0]->cehooks[cmdid] = nvme_complete_adminevent;
+    dev->dev_Queues[0]->cehandlers[cmdid] = handler;
 
     if (handler) {
         /* clear the signal first */
@@ -55,6 +63,14 @@ int nvme_submit_admincmd(device_t dev, struct nvme_command *cmd, struct completi
     }
 
     retval = nvme_submit_cmd(dev->dev_Queues[0], cmd);
+    if (retval != 0) {
+        dev->dev_Queues[0]->cehooks[cmdid] = NULL;
+        dev->dev_Queues[0]->cehandlers[cmdid] = NULL;
+        if (handler) {
+            nvme_dma_release(handler, TRUE);
+        }
+        nvme_release_cmdid(dev->dev_Queues[0], cmdid);
+    }
 
     return retval;
 }

--- a/rom/devs/nvme/nvme_queue_io.c
+++ b/rom/devs/nvme/nvme_queue_io.c
@@ -7,8 +7,8 @@
 #include <devices/newstyle.h>
 #include <asm/io.h>
 #include <hidd/pci.h>
-#include <interface/Hidd_PCIDriver.h>
 #include <exec/errors.h>
+#include <exec/memory.h>
 
 #include <string.h>
 
@@ -29,31 +29,27 @@ void nvme_complete_ioevent(struct nvme_queue *nvmeq, struct nvme_completion *cqe
 {
     D(bug ("[NVME:IOQ] %s(0x%p)\n", __func__, cqe);)
     if (nvmeq->cehandlers[cqe->command_id]) {
+        struct completionevent_handler *slot = nvmeq->cehandlers[cqe->command_id];
+
         D(bug ("[NVME:IOQ] %s: completing queue entry #%u\n", __func__, cqe->command_id);)
 
-        nvmeq->cehandlers[cqe->command_id]->ceh_Reply = TRUE;
-        nvmeq->cehandlers[cqe->command_id]->ceh_Result = AROS_LE2LONG(cqe->result);
-        nvmeq->cehandlers[cqe->command_id]->ceh_Status = (AROS_LE2WORD(cqe->status) >> 1) & ~(3 << 12); //Cache the status flag masking out the reserved bits
+        slot->ceh_Reply = TRUE;
+        slot->ceh_Result = AROS_LE2LONG(cqe->result);
+        slot->ceh_Status = (AROS_LE2WORD(cqe->status) >> 1) & ~(3 << 12); //Cache the status flag masking out the reserved bits
 
         {
-            struct IOExtTD *iotd = (struct IOExtTD *)nvmeq->cehandlers[cqe->command_id]->ceh_Msg;
-            APTR dma;
-            LONG iolen;
+            struct IOExtTD *iotd = (struct IOExtTD *)slot->ceh_Msg;
 
-            dma = iotd->iotd_Req.io_Data;
-            iolen = (LONG)iotd->iotd_Req.io_Length;
+            nvme_dma_release(slot, TRUE);
 
-            if ((iotd->iotd_Req.io_Command == CMD_WRITE) ||
+            if (!((iotd->iotd_Req.io_Command == CMD_WRITE) ||
                     (iotd->iotd_Req.io_Command == TD_WRITE64) ||
                     (iotd->iotd_Req.io_Command == NSCMD_TD_WRITE64) ||
                     (iotd->iotd_Req.io_Command == TD_FORMAT) ||
-                    (iotd->iotd_Req.io_Command == TD_FORMAT64)) {
-                CachePostDMA(dma, &iolen, DMAFLAGS_POSTWRITE);
-            } else {
+                    (iotd->iotd_Req.io_Command == TD_FORMAT64))) {
                 UBYTE *tmpdata = iotd->iotd_Req.io_Data;
                 ULONG x;
 
-                CachePostDMA(dma, &iolen, DMAFLAGS_POSTREAD);
 #if defined(NVME_DUMP_READS)
                 bug("[NVME:IOQ] %s: Read Data-:", __func__);
                 for (x = 0; x < iotd->iotd_Req.io_Length; x++) {
@@ -67,19 +63,19 @@ void nvme_complete_ioevent(struct nvme_queue *nvmeq, struct nvme_completion *cqe
 #endif
             }
             /* Free up allocations used for the transfer */
-            if (nvmeq->cehandlers[cqe->command_id]->ceh_IOMem.me_Un.meu_Addr) {
+            if (slot->ceh_IOMem.me_Un.meu_Addr) {
 #if (0)
-                ULONG iolen = nvmeq->cehandlers[cqe->command_id]->ceh_IOMem.me_Length;
-                CachePostDMA(nvmeq->cehandlers[cqe->command_id]->ceh_IOMem.me_Un.meu_Addr, &iolen, DMAFLAGS_POSTREAD);
+                ULONG iolen = slot->ceh_IOMem.me_Length;
+                CachePostDMA(slot->ceh_IOMem.me_Un.meu_Addr, &iolen, DMAFLAGS_POSTREAD);
 #endif
-                D(bug ("[NVME:IOQ] %s: Releasing IO Allocation @ %p (%ubytes)\n", __func__, nvmeq->cehandlers[cqe->command_id]->ceh_IOMem.me_Un.meu_Addr, nvmeq->cehandlers[cqe->command_id]->ceh_IOMem.me_Length);)
-                FreeMem(nvmeq->cehandlers[cqe->command_id]->ceh_IOMem.me_Un.meu_Addr, nvmeq->cehandlers[cqe->command_id]->ceh_IOMem.me_Length);
+                D(bug ("[NVME:IOQ] %s: Releasing IO Allocation @ %p (%ubytes)\n", __func__, slot->ceh_IOMem.me_Un.meu_Addr, slot->ceh_IOMem.me_Length);)
+                FreeMem(slot->ceh_IOMem.me_Un.meu_Addr, slot->ceh_IOMem.me_Length);
 
-                nvmeq->cehandlers[cqe->command_id]->ceh_IOMem.me_Un.meu_Addr = NULL;
+                slot->ceh_IOMem.me_Un.meu_Addr = NULL;
             }
 
-            if (nvmeq->cehandlers[cqe->command_id]->ceh_Status) {
-                UBYTE sct = (nvmeq->cehandlers[cqe->command_id]->ceh_Status >> 7) & 0x7, sc = (nvmeq->cehandlers[cqe->command_id]->ceh_Status) & 0x7F;
+            if (slot->ceh_Status) {
+                UBYTE sct = (slot->ceh_Status >> 7) & 0x7, sc = (slot->ceh_Status) & 0x7F;
                 iotd->iotd_Req.io_Error = IOERR_ABORTED;
                 D(bug("[NVME:IOQ] %s: NVME IO Error %u:%u\n", __func__, sct, sc);)
             } else {
@@ -88,26 +84,63 @@ void nvme_complete_ioevent(struct nvme_queue *nvmeq, struct nvme_completion *cqe
             }
         }
 
-        D(bug ("[NVME:IOQ] %s: Signaling 0x%p (%08x)\n", __func__, nvmeq->cehandlers[cqe->command_id]->ceh_Task, nvmeq->cehandlers[cqe->command_id]->ceh_SigSet);)
-        Signal(nvmeq->cehandlers[cqe->command_id]->ceh_Task, nvmeq->cehandlers[cqe->command_id]->ceh_SigSet);
+        D(bug ("[NVME:IOQ] %s: Signaling 0x%p (%08x)\n", __func__, slot->ceh_Task, slot->ceh_SigSet);)
+        Signal(slot->ceh_Task, slot->ceh_SigSet);
     }
 }
 
-int nvme_submit_iocmd(struct completionevent_handler *ce,
-                      struct nvme_queue *nvmeq,
+int nvme_submit_iocmd(struct nvme_queue *nvmeq,
                       struct nvme_command *cmd,
                       struct completionevent_handler *handler)
 {
     int retval;
+    int cmdid;
+    struct completionevent_handler *slot;
 
-    D(bug ("[NVME:IOQ] %s(0x%p, 0x%p)\n", __func__, cmd);)
+    D(bug ("[NVME:IOQ] %s(0x%p, 0x%p)\n", __func__, nvmeq, cmd);)
 
-    handler->ceh_Reply = FALSE;
-    cmd->common.op.command_id = nvme_alloc_cmdid(nvmeq);
-    nvmeq->cehooks[cmd->common.op.command_id] = nvme_complete_ioevent;
-    nvmeq->cehandlers[cmd->common.op.command_id] = &ce[cmd->common.op.command_id];
-    CopyMem(handler, &ce[cmd->common.op.command_id], sizeof(struct completionevent_handler));
+    cmdid = nvme_alloc_cmdid(nvmeq);
+    if (cmdid < 0) {
+        return -1;
+    }
+
+    slot = &nvmeq->ce_entries[cmdid];
+    CopyMem(handler, slot, sizeof(struct completionevent_handler));
+    slot->ceh_Reply = FALSE;
+
+    if (handler->ceh_DMAMapCount > NVME_INLINE_DMA_SEGMENTS) {
+        slot->ceh_DMAMap = AllocMem(handler->ceh_DMAMapCount * sizeof(struct nvme_dma_segment), MEMF_ANY | MEMF_CLEAR);
+        if (!slot->ceh_DMAMap) {
+            nvme_release_cmdid(nvmeq, cmdid);
+            nvme_dma_release(handler, TRUE);
+            return -1;
+        }
+        CopyMem(handler->ceh_DMAMap, slot->ceh_DMAMap,
+                handler->ceh_DMAMapCount * sizeof(struct nvme_dma_segment));
+        slot->ceh_DMAMapCapacity = handler->ceh_DMAMapCount;
+    } else {
+        if (handler->ceh_DMAMapCount) {
+            CopyMem(handler->ceh_DMAMap, slot->ceh_DMAInline,
+                    handler->ceh_DMAMapCount * sizeof(struct nvme_dma_segment));
+        }
+        slot->ceh_DMAMap = slot->ceh_DMAInline;
+        slot->ceh_DMAMapCapacity = NVME_INLINE_DMA_SEGMENTS;
+    }
+    slot->ceh_DMAMapCount = handler->ceh_DMAMapCount;
+
+    nvme_dma_reset(handler);
+
+    cmd->common.op.command_id = cmdid;
+    nvmeq->cehooks[cmdid] = nvme_complete_ioevent;
+    nvmeq->cehandlers[cmdid] = slot;
+
     retval = nvme_submit_cmd(nvmeq, cmd);
+    if (retval != 0) {
+        nvmeq->cehooks[cmdid] = NULL;
+        nvmeq->cehandlers[cmdid] = NULL;
+        nvme_dma_release(slot, TRUE);
+        nvme_release_cmdid(nvmeq, cmdid);
+    }
 
     return retval;
 }

--- a/rom/devs/nvme/nvme_queue_io.h
+++ b/rom/devs/nvme/nvme_queue_io.h
@@ -4,7 +4,6 @@
 #define DMAFLAGS_POSTREAD    (1 << 31)
 #define DMAFLAGS_POSTWRITE   (1 << 31) | DMA_ReadFromRAM
 
-int nvme_submit_iocmd(struct completionevent_handler *ce,
-                                    struct nvme_queue *nvmeq,
+int nvme_submit_iocmd(struct nvme_queue *nvmeq,
                                     struct nvme_command *cmd,
                                     struct completionevent_handler *handler);

--- a/rom/devs/nvme/nvme_sgl.c
+++ b/rom/devs/nvme/nvme_sgl.c
@@ -40,8 +40,138 @@
 
 #include LC_LIBDEFS_FILE
 
+#ifndef DMA_Continue
+#define DMA_Continue    (1L << 1)
+#endif
+
+#define NVME_CMD_PSDT_MASK      (3 << 6)
+#define NVME_CMD_PSDT_SGL       (2 << 6)
+#define NVME_SGL_DESC_TYPE_DATA_BLOCK   0x00
+
+struct nvme_sgl_descriptor {
+    UQUAD address;
+    ULONG length;
+    UBYTE rsvd[3];
+    UBYTE type;
+};
+
 BOOL nvme_initsgl(struct nvme_command *cmdio, struct completionevent_handler *ioehandle, struct nvme_Unit *unit, ULONG len, APTR *data, BOOL is_write)
 {
-    bug("[NVME%02ld] %s: SGL support not yet implemented!\n", unit->au_UnitNum, __func__);
-    return FALSE;
+    device_t dev = unit->au_Bus->ab_Dev;
+    ULONG page_size;
+    ULONG max_segments;
+    ULONG capacity;
+    ULONG alloc_len;
+    struct nvme_sgl_descriptor *sgl;
+    ULONG remaining = len;
+    UBYTE *cpu_ptr = (UBYTE *)*data;
+    ULONG flags = is_write ? DMAFLAGS_PREWRITE : DMAFLAGS_PREREAD;
+    ULONG descriptor_count = 0;
+    struct NVMEBase *NVMEBase = dev ? dev->dev_NVMEBase : NULL;
+
+    if (!dev || !dev->dev_PCIDriverObject || !NVMEBase) {
+        return FALSE;
+    }
+
+    (void)NVMEBase;
+
+    page_size = dev->pagesize;
+
+    if (len == 0) {
+        return FALSE;
+    }
+
+    max_segments = (len + page_size - 1) / page_size;
+    if (max_segments == 0) {
+        max_segments = 1;
+    }
+
+    capacity = max_segments;
+    alloc_len = (capacity * sizeof(struct nvme_sgl_descriptor)) + 16;
+    ioehandle->ceh_IOMem.me_Length = alloc_len;
+    ioehandle->ceh_IOMem.me_Un.meu_Addr = AllocMem(alloc_len, MEMF_ANY | MEMF_CLEAR);
+    if (!ioehandle->ceh_IOMem.me_Un.meu_Addr) {
+        return FALSE;
+    }
+
+    sgl = (struct nvme_sgl_descriptor *)(((IPTR)ioehandle->ceh_IOMem.me_Un.meu_Addr + 15) & ~15);
+
+    while (remaining > 0) {
+        ULONG chunk = remaining;
+        APTR phys = CachePreDMA(cpu_ptr, &chunk, flags);
+
+        if (!phys || chunk == 0) {
+            FreeMem(ioehandle->ceh_IOMem.me_Un.meu_Addr, ioehandle->ceh_IOMem.me_Length);
+            ioehandle->ceh_IOMem.me_Un.meu_Addr = NULL;
+            return FALSE;
+        }
+
+        if (!nvme_dma_append(ioehandle, cpu_ptr, chunk, flags)) {
+            FreeMem(ioehandle->ceh_IOMem.me_Un.meu_Addr, ioehandle->ceh_IOMem.me_Length);
+            ioehandle->ceh_IOMem.me_Un.meu_Addr = NULL;
+            return FALSE;
+        }
+
+        if (descriptor_count >= capacity) {
+            ULONG new_capacity = capacity << 1;
+            if (new_capacity <= capacity) {
+                FreeMem(ioehandle->ceh_IOMem.me_Un.meu_Addr, ioehandle->ceh_IOMem.me_Length);
+                ioehandle->ceh_IOMem.me_Un.meu_Addr = NULL;
+                return FALSE;
+            }
+            ULONG new_alloc = (new_capacity * sizeof(struct nvme_sgl_descriptor)) + 16;
+            APTR new_storage = AllocMem(new_alloc, MEMF_ANY | MEMF_CLEAR);
+
+            if (!new_storage) {
+                FreeMem(ioehandle->ceh_IOMem.me_Un.meu_Addr, ioehandle->ceh_IOMem.me_Length);
+                ioehandle->ceh_IOMem.me_Un.meu_Addr = NULL;
+                return FALSE;
+            }
+
+            struct nvme_sgl_descriptor *new_sgl = (struct nvme_sgl_descriptor *)(((IPTR)new_storage + 15) & ~15);
+
+            CopyMem(sgl, new_sgl, descriptor_count * sizeof(struct nvme_sgl_descriptor));
+
+            FreeMem(ioehandle->ceh_IOMem.me_Un.meu_Addr, ioehandle->ceh_IOMem.me_Length);
+
+            ioehandle->ceh_IOMem.me_Un.meu_Addr = new_storage;
+            ioehandle->ceh_IOMem.me_Length = new_alloc;
+
+            sgl = new_sgl;
+            capacity = new_capacity;
+        }
+
+        sgl[descriptor_count].address = AROS_QUAD2LE((UQUAD)(IPTR)HIDD_PCIDriver_CPUtoPCI(dev->dev_PCIDriverObject, phys));
+        sgl[descriptor_count].length = AROS_LONG2LE(chunk);
+        sgl[descriptor_count].rsvd[0] = sgl[descriptor_count].rsvd[1] = sgl[descriptor_count].rsvd[2] = 0;
+        sgl[descriptor_count].type = NVME_SGL_DESC_TYPE_DATA_BLOCK;
+        descriptor_count++;
+
+        remaining -= chunk;
+        cpu_ptr += chunk;
+        flags = (is_write ? DMAFLAGS_PREWRITE : DMAFLAGS_PREREAD) | DMA_Continue;
+    }
+
+    {
+        ULONG sgl_bytes = descriptor_count * sizeof(struct nvme_sgl_descriptor);
+        APTR sgl_phys = CachePreDMA(sgl, &sgl_bytes, DMAFLAGS_PREWRITE);
+
+        if (!sgl_phys || sgl_bytes < descriptor_count * sizeof(struct nvme_sgl_descriptor)) {
+            FreeMem(ioehandle->ceh_IOMem.me_Un.meu_Addr, ioehandle->ceh_IOMem.me_Length);
+            ioehandle->ceh_IOMem.me_Un.meu_Addr = NULL;
+            return FALSE;
+        }
+
+        if (!nvme_dma_append(ioehandle, sgl, descriptor_count * sizeof(struct nvme_sgl_descriptor), DMAFLAGS_PREWRITE)) {
+            FreeMem(ioehandle->ceh_IOMem.me_Un.meu_Addr, ioehandle->ceh_IOMem.me_Length);
+            ioehandle->ceh_IOMem.me_Un.meu_Addr = NULL;
+            return FALSE;
+        }
+
+        cmdio->rw.op.flags = (cmdio->rw.op.flags & ~NVME_CMD_PSDT_MASK) | NVME_CMD_PSDT_SGL;
+        cmdio->rw.prp1 = AROS_QUAD2LE((UQUAD)(IPTR)HIDD_PCIDriver_CPUtoPCI(dev->dev_PCIDriverObject, sgl_phys));
+        cmdio->rw.prp2 = 0;
+    }
+
+    return TRUE;
 }


### PR DESCRIPTION
## Summary
- attempt scatter/gather descriptor construction first when the controller exposes SGL capability flags
- fall back to PRP programming only if SGL setup is unavailable or fails, resetting DMA bookkeeping before retrying

## Testing
- not run (build tooling unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68fb77d67044832984b99ddc35c7d0cc