### PR TITLE
Fix timerreq propagation and function signatures in xHCI scheduling and command paths

### DIFF
--- a/rom/usb/pciusb/pciusb_arospci.c
+++ b/rom/usb/pciusb/pciusb_arospci.c
@@ -434,7 +434,7 @@ BOOL pciAllocUnit(struct PCIUnit *hu)
                 if(xhciports) {
                     pciusbWarn("PCI", "More than one XHCI controller per board?!?\n");
                 }
-                allocgood = xhciInit(hc,hu);
+                allocgood = xhciInit(hc, hu, hu->hu_TimerReq);
                 if(allocgood) {
                     xhcicnt++;
                     xhciports = hc->hc_NumPorts;

--- a/rom/usb/pciusb/xhcichip_hcport.c
+++ b/rom/usb/pciusb/xhcichip_hcport.c
@@ -289,7 +289,7 @@ BOOL xhciSetFeature(struct PCIUnit *unit, struct PCIController *hc,
                 DEBUGCOLOR_SET "xHCI: PORT_RESET: disabling device slot (%u) for re-enumeration"
                 DEBUGCOLOR_RESET "\n", devCtx->dc_SlotID);
 
-            xhciDisconnectDevice(hc, devCtx);
+            xhciDisconnectDevice(hc, devCtx, unit->hu_TimerReq);
         }
 
         if (oldval & XHCIF_PR_PORTSC_CCS) {
@@ -402,7 +402,7 @@ BOOL xhciClearFeature(struct PCIUnit *unit, struct PCIController *hc,
 
         devCtx = xhciFindPortDevice(hc, hciport);
         if (devCtx) {
-            xhciDisconnectDevice(hc, devCtx);
+            xhciDisconnectDevice(hc, devCtx, unit->hu_TimerReq);
         }
 
         /* Attempt to clear PED via masked write (won't disturb RO fields). */
@@ -758,7 +758,8 @@ AROS_UFH0(void, xhciPortTask)
                                                  rootPort,
                                                  route,
                                                  flags,
-                                                 mps0);
+                                                 mps0,
+                                                 hc->hc_Unit->hu_TimerReq);
                     if (devCtx) {
                         /* Root port "device" lives on this controller */
                         hc->hc_Unit->hu_DevControllers[0] = hc;
@@ -771,7 +772,7 @@ AROS_UFH0(void, xhciPortTask)
                                     DEBUGCOLOR_SET "Detaching HCI Device Ctx @ 0x%p" DEBUGCOLOR_RESET" \n",
                                     devCtx);
 
-                    xhciDisconnectDevice(hc, devCtx);
+                    xhciDisconnectDevice(hc, devCtx, hc->hc_Unit->hu_TimerReq);
                 }
             }
             uhwCheckRootHubChanges(hc->hc_Unit);

--- a/rom/usb/pciusb/xhcichip_isoch.c
+++ b/rom/usb/pciusb/xhcichip_isoch.c
@@ -201,7 +201,8 @@ void xhciStartIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
 
     if (!ioreq->iouh_DriverPrivate1) {
         struct pciusbXHCIIODevPrivate *driprivate = NULL;
-        if (!xhciInitIOTRBTransfer(hc, ioreq, &hc->hc_IsoXFerQueue, UHCMD_ISOXFER, FALSE, &driprivate))
+        if (!xhciInitIOTRBTransfer(hc, ioreq, &hc->hc_IsoXFerQueue, UHCMD_ISOXFER, FALSE,
+                                   hc->hc_Unit->hu_TimerReq, &driprivate))
             return;
     }
 

--- a/rom/usb/pciusb/xhcichip_schedule.h
+++ b/rom/usb/pciusb/xhcichip_schedule.h
@@ -12,8 +12,9 @@ void xhciReleaseDMABuffer(struct PCIController *hc, struct IOUsbHWReq *ioreq,
         ULONG actual, UWORD effdir, APTR bounceBuf);
 
 BOOL xhciInitIOTRBTransfer(struct PCIController *hc, struct IOUsbHWReq *ioreq,
-        struct List *ownerList, ULONG txtype, BOOL allowEp0AutoCreate,
-        struct pciusbXHCIIODevPrivate **outPrivate);
+    struct List *ownerList, ULONG txtype, BOOL allowEp0AutoCreate,
+    struct timerequest *timerreq,
+    struct pciusbXHCIIODevPrivate **outPrivate);
 
 ULONG xhciBuildDataTRBFlags(const struct IOUsbHWReq *ioreq, ULONG txtype);
 


### PR DESCRIPTION
### Motivation

- Continue threading the per-task `timerreq` through xHCI command and scheduling paths to avoid implicit use of `hu->hu_TimerReq` and to make timeouts task-safe.
- Resolve compile-time errors caused by mismatched function signatures and incorrect call sites after prior changes that added `timerreq` parameters.
- Ensure command submission and endpoint/device lifecycle operations use the caller-provided `timerreq` so waits/delays happen on the correct timer context.

### Description

- Updated function signatures and forward declarations to accept `struct timerequest *timerreq` where needed, including `xhciCmdSubmit`, command helpers/macros, `xhciFreeEndpointContext`, `xhciCreateDeviceCtx`, `xhciObtainDeviceCtx`, `xhciInitIOTRBTransfer`, `xhciHandleFinishedTDs`, `xhciInit`, `xhciReset`, `xhciPowerOnRootPorts`, `xhciFreeDeviceCtx`, and `xhciDisconnectDevice`.
- Propagated `timerreq` into scheduling paths by modifying `xhcichip_schedule.c`/`xhcichip_schedule.h` so `xhciObtainHWEndpoint` and `xhciInitIOTRBTransfer` receive the `timerreq` and pass it to endpoint/configure/command helpers.
- Adjusted call sites to pass `unit->hu_TimerReq` for initialization/opener code and `hc->hc_Unit->hu_TimerReq` (or the provided `timerreq`) in task/context paths, and updated `xhcichip`/`xhcichip_hw`/`xhcidevice`/`xhcichip_isoch`/`xhcichip_hcport` accordingly.
- Updated public/internal headers `xhciproto.h` and `xhcichip_schedule.h` to reflect the new signatures and inline macro variants that include `timerreq`.

### Testing

- No automated tests were executed for this change set.
- Compilation was not run as part of this PR, but the changes specifically address prior compiler errors (incompatible pointer types and incorrect argument counts) by aligning declarations and call sites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954f9ab23008329826219cc3bcdd4f1)