### PR TITLE
xHCI: refactor task state into per-task structs and rename event signal

### DIFF
--- a/rom/usb/pciusb/xhcichip.h
+++ b/rom/usb/pciusb/xhcichip.h
@@ -13,6 +13,9 @@
 #include "pciusb.h"
 #include "hccommon.h"
 
+struct MsgPort;
+struct timerequest;
+
 #ifndef DMAFLAGS_PREREAD
 #define DMAFLAGS_PREREAD     0
 #endif
@@ -62,6 +65,22 @@ struct pciusbXHCITRBParams
     ULONG                       status;
 };
 
+struct XhciPortTaskPrivate
+{
+    struct Task                    *xpt_Task;
+    BYTE                            xpt_PortChangeSignal;
+    struct MsgPort                 *xpt_TimerPort;
+    struct timerequest             *xpt_TimerReq;
+};
+
+struct XhciEventTaskPrivate
+{
+    struct Task                    *xet_Task;
+    BYTE                            xet_ProcessEventsSignal;
+    struct MsgPort                 *xet_TimerPort;
+    struct timerequest             *xet_TimerReq;
+};
+
 struct XhciHCPrivate
 {
     UWORD                               xhc_NumSlots;
@@ -97,12 +116,10 @@ struct XhciHCPrivate
     APTR                                xhc_XHCIIntR;
 
     BYTE                                xhc_ReadySignal;
-    BYTE                                xhc_PortChangeSignal;
-    BYTE                                xhc_DoWorkSignal;
     UWORD                               xhc_RootPortChanges;
     struct Task                        *xhc_ReadySigTask;
-    struct Task                        *xhc_xHCERTask;
-    struct Task                        *xhc_xHCPortTask;
+    struct XhciPortTaskPrivate         xhc_PortTask;
+    struct XhciEventTaskPrivate        xhc_EventTask;
     struct pciusbXHCIDevice            *xhc_Devices[USB_DEV_MAX];
     volatile struct pciusbXHCITRBParams xhc_CmdResults[USB_DEV_MAX];
     UBYTE                               xhc_PortProtocol[MAX_ROOT_PORTS];


### PR DESCRIPTION
### Motivation
- Consolidate per-task state for the xHCI port and event tasks into dedicated structures to improve clarity and reduce scattered fields in `XhciHCPrivate`.
- Rename the ambiguous event-task signal to make its purpose clearer by using `xhc_ProcessEventsSignal` in the new event-task private struct.
- Use per-task timer resources consistently by referencing timer fields from the per-task structs instead of global fields.

### Description
- Added forward declarations for `struct MsgPort` and `struct timerequest` and introduced `XhciPortTaskPrivate` and `XhciEventTaskPrivate` in `xhcichip.h`.
- Replaced the old task/signal/timer fields in `struct XhciHCPrivate` with `xhc_PortTask` and `xhc_EventTask` instances and renamed the event signal field to `xet_ProcessEventsSignal`.
- Updated all call sites in `xhcichip.c`, `xhcichip_hw.c`, and `xhcichip_hcport.c` to use the new struct fields (task, signal, `timerPort`, `timerReq`) and added cleanup code to free signals and close task timers.
- Added inline helpers `xhciOpenTaskTimer` and `xhciCloseTaskTimer` to `xhciproto.h` and used them when opening/closing per-task `timer.device` resources.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69550565b134832982361ffe33370b4a)