### PR TITLE
xHCI: support multi-PTD in-flight RTIso (double-buffering)

### DIFF
--- a/rom/usb/pciusb/pciusb.h
+++ b/rom/usb/pciusb/pciusb.h
@@ -82,6 +82,7 @@ struct PTDNode
 #define PTDF_ACTIVE             (1<<0)
 #define PTDF_BUFFER_VALID       (1<<1)
 #define PTDF_SITD               (1<<2)
+#define PTDF_QUEUED             (1<<3)
 
 #define PCIUSB_ISO_PTD_COUNT    8
 

--- a/rom/usb/pciusb/pciusb.h
+++ b/rom/usb/pciusb/pciusb.h
@@ -60,6 +60,8 @@
 #define USB_DEV_MAX                     128
 #define USB_DEVEP_CNT                   (USB_DEV_MAX * MAX_DEVENDPOINTS)
 
+struct RTIsoNode;
+
 struct PTDNode
 {
     struct MinNode              ptd_Node;
@@ -72,6 +74,9 @@ struct PTDNode
     UWORD                       ptd_PktLength[8];
     UWORD                       ptd_Flags;
     struct PTDNode             *ptd_NextPTD;
+    struct IOUsbHWReq           ptd_IOReq;
+    struct IOUsbHWBufferReq     ptd_BufferReq;
+    struct RTIsoNode           *ptd_RTIsoNode;
 };
 
 #define PTDF_ACTIVE             (1<<0)

--- a/rom/usb/pciusb/uhwcmd.c
+++ b/rom/usb/pciusb/uhwcmd.c
@@ -19,7 +19,7 @@
 static inline BOOL uhwIsRootHubIOReq(const struct IOUsbHWReq *ioreq,
                                      const struct PCIUnit *unit)
 {
-    /* Root hub “device” is not behind any port/hub route. */
+    /* Root hub â€œdeviceâ€ is not behind any port/hub route. */
     return (ioreq->iouh_DevAddr == unit->hu_RootHubAddr) &&
            (ioreq->iouh_RouteString == 0) &&
            (ioreq->iouh_RootPort == 0);
@@ -1848,7 +1848,8 @@ WORD cmdStartRTIso(struct IOUsbHWReq *ioreq,
 
     switch(hc->hc_HCIType) {
     case HCITYPE_XHCI:
-        xhciStartIsochIO(hc, rtn);
+        for (UWORD cnt = 0; cnt < prefill; cnt++)
+            xhciStartIsochIO(hc, rtn);
         break;
     case HCITYPE_EHCI:
         ehciStartIsochIO(hc, rtn);

--- a/rom/usb/pciusb/xhcichip.c
+++ b/rom/usb/pciusb/xhcichip.c
@@ -2099,10 +2099,10 @@ void xhciFinishRequest(struct PCIController *hc, struct PCIUnit *unit, struct IO
     }
     devadrep = xhciDevEPKey(ioreq);
     pciusbXHCIDebugEPV("xHCI", DEBUGCOLOR_SET "%s: releasing DevEP %02lx" DEBUGCOLOR_RESET" \n", __func__, devadrep);
-    if (ioreq->iouh_Req.io_Command != UHCMD_ISOXFER) {
+    if (unit->hu_DevBusyReq[devadrep] == ioreq)
         unit->hu_DevBusyReq[devadrep] = NULL;
+    if (ioreq->iouh_Req.io_Command != UHCMD_ISOXFER)
         unit->hu_NakTimeoutFrame[devadrep] = 0;
-    }
 }
 
 static inline void xhciIOErrfromCC(struct IOUsbHWReq *ioreq, ULONG cc)

--- a/rom/usb/pciusb/xhcichip.c
+++ b/rom/usb/pciusb/xhcichip.c
@@ -2099,8 +2099,10 @@ void xhciFinishRequest(struct PCIController *hc, struct PCIUnit *unit, struct IO
     }
     devadrep = xhciDevEPKey(ioreq);
     pciusbXHCIDebugEPV("xHCI", DEBUGCOLOR_SET "%s: releasing DevEP %02lx" DEBUGCOLOR_RESET" \n", __func__, devadrep);
-    unit->hu_DevBusyReq[devadrep] = NULL;
-    unit->hu_NakTimeoutFrame[devadrep] = 0;
+    if (ioreq->iouh_Req.io_Command != UHCMD_ISOXFER) {
+        unit->hu_DevBusyReq[devadrep] = NULL;
+        unit->hu_NakTimeoutFrame[devadrep] = 0;
+    }
 }
 
 static inline void xhciIOErrfromCC(struct IOUsbHWReq *ioreq, ULONG cc)

--- a/rom/usb/pciusb/xhcichip.c
+++ b/rom/usb/pciusb/xhcichip.c
@@ -2387,24 +2387,41 @@ void xhciHandleFinishedTDs(struct PCIController *hc, struct timerequest *timerre
                             (LONG)ioreq->iouh_Req.io_Error,
                             (unsigned long)actual);
 
-            struct RTIsoNode *rtn = (struct RTIsoNode *)ioreq->iouh_DriverPrivate2;
+            struct PTDNode *ptd = (struct PTDNode *)ioreq->iouh_DriverPrivate2;
+            struct RTIsoNode *rtn = ptd ? ptd->ptd_RTIsoNode : NULL;
             if (rtn && rtn->rtn_RTIso) {
                 struct IOUsbHWRTIso *urti = rtn->rtn_RTIso;
-                rtn->rtn_BufferReq.ubr_Length = actual;
-                rtn->rtn_BufferReq.ubr_Frame = ioreq->iouh_Frame;
+                struct IOUsbHWBufferReq *bufreq = ptd ? &ptd->ptd_BufferReq : &rtn->rtn_BufferReq;
+                bufreq->ubr_Length = actual;
+                bufreq->ubr_Frame = ioreq->iouh_Frame;
                 if (ioreq->iouh_Dir == UHDIR_IN) {
                     if (urti->urti_InDoneHook)
-                        CallHookPkt(urti->urti_InDoneHook, rtn, &rtn->rtn_BufferReq);
+                        CallHookPkt(urti->urti_InDoneHook, rtn, bufreq);
                 } else {
                     if (urti->urti_OutDoneHook)
-                        CallHookPkt(urti->urti_OutDoneHook, rtn, &rtn->rtn_BufferReq);
+                        CallHookPkt(urti->urti_OutDoneHook, rtn, bufreq);
                 }
 
                 xhciFreePeriodicContext(hc, unit, ioreq);
                 ioreq->iouh_Actual = 0;
                 ioreq->iouh_Req.io_Error = 0;
-                if (xhciQueueIsochIO(hc, rtn) == RC_OK)
+                if (ptd)
+                    ptd->ptd_Flags &= ~(PTDF_ACTIVE | PTDF_BUFFER_VALID);
+
+                UWORD pending = 0;
+                UWORD target = (rtn->rtn_PTDCount > 1) ? 2 : 1;
+                for (UWORD idx = 0; idx < rtn->rtn_PTDCount; idx++) {
+                    struct PTDNode *scan = rtn->rtn_PTDs[idx];
+                    if (scan && (scan->ptd_Flags & (PTDF_ACTIVE | PTDF_BUFFER_VALID)))
+                        pending++;
+                }
+
+                while (pending < target) {
+                    if (xhciQueueIsochIO(hc, rtn) != RC_OK)
+                        break;
                     xhciStartIsochIO(hc, rtn);
+                    pending++;
+                }
                 ioreq = nextioreq;
                 continue;
             }

--- a/rom/usb/pciusb/xhcichip_isoch.c
+++ b/rom/usb/pciusb/xhcichip_isoch.c
@@ -65,7 +65,8 @@ void xhciScheduleIsoTDs(struct PCIController *hc)
     ForeachNodeSafe(&hc->hc_IsoXFerQueue, ioreq, ionext) {
         devadrep = xhciDevEPKey(ioreq);
 
-        if(unit->hu_DevBusyReq[devadrep]) {
+        if (unit->hu_DevBusyReq[devadrep] &&
+            unit->hu_DevBusyReq[devadrep]->iouh_Req.io_Command != UHCMD_ISOXFER) {
             pciusbWarn("xHCI", "DevEP %02lx in use!\n", devadrep);
             continue;
         }
@@ -79,6 +80,8 @@ void xhciScheduleIsoTDs(struct PCIController *hc)
             pciusbError("xHCI",
                         DEBUGWARNCOLOR_SET "xHCI: Missing prepared ISO transfer context for Dev=%u EP=%u" DEBUGCOLOR_RESET" \n",
                         ioreq->iouh_DevAddr, ioreq->iouh_Endpoint);
+            if (ptd)
+                ptd->ptd_Flags &= ~(PTDF_ACTIVE | PTDF_BUFFER_VALID | PTDF_QUEUED);
             Remove(&ioreq->iouh_Req.io_Message.mn_Node);
             ioreq->iouh_Req.io_Error = UHIOERR_HOSTERROR;
             ReplyMsg(&ioreq->iouh_Req.io_Message);
@@ -101,6 +104,8 @@ void xhciScheduleIsoTDs(struct PCIController *hc)
         trbflags |= TRBF_FLAG_FRAMEID(ioreq->iouh_Frame);
 
         Remove(&ioreq->iouh_Req.io_Message.mn_Node);
+        if (ptd)
+            ptd->ptd_Flags &= ~PTDF_QUEUED;
 
         BOOL txdone = FALSE;
         driprivate->dpSTRB = (UWORD)-1;
@@ -273,6 +278,7 @@ void xhciStartIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
     for (UWORD idx = 0; idx < rtn->rtn_PTDCount; idx++) {
         struct PTDNode *candidate = rtn->rtn_PTDs[idx];
         if (candidate && (candidate->ptd_Flags & PTDF_BUFFER_VALID) &&
+            !(candidate->ptd_Flags & PTDF_QUEUED) &&
             !(candidate->ptd_Flags & PTDF_ACTIVE)) {
             ptd = candidate;
             break;
@@ -304,6 +310,7 @@ void xhciStartIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
     }
 
     /* Queue it on the ISO path. */
+    ptd->ptd_Flags |= PTDF_QUEUED;
     AddTail(&hc->hc_IsoXFerQueue, (struct Node *)&ioreq->iouh_Req.io_Message.mn_Node);
     xhciScheduleIsoTDs(hc);
 }

--- a/rom/usb/pciusb/xhcichip_isoch.c
+++ b/rom/usb/pciusb/xhcichip_isoch.c
@@ -263,6 +263,7 @@ WORD xhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
 
     ptd->ptd_FrameIdx = bufreq->ubr_Frame;
     ptd->ptd_Flags |= PTDF_BUFFER_VALID;
+    rtn->rtn_BufferReq = *bufreq;
 
     return RC_OK;
 }

--- a/rom/usb/pciusb/xhcichip_isoch.c
+++ b/rom/usb/pciusb/xhcichip_isoch.c
@@ -32,6 +32,27 @@
 #define LogResBase (base->hd_LogResBase)
 #endif
 
+static struct PTDNode *xhciNextIsoPTD(struct RTIsoNode *rtn)
+{
+    if (!rtn || !rtn->rtn_PTDs || !rtn->rtn_PTDCount)
+        return NULL;
+
+    for (UWORD offset = 0; offset < rtn->rtn_PTDCount; offset++) {
+        UWORD idx = (rtn->rtn_NextPTD + offset) % rtn->rtn_PTDCount;
+        struct PTDNode *ptd = rtn->rtn_PTDs[idx];
+
+        if (!ptd)
+            continue;
+
+        if (!(ptd->ptd_Flags & (PTDF_ACTIVE | PTDF_BUFFER_VALID))) {
+            rtn->rtn_NextPTD = (idx + 1) % rtn->rtn_PTDCount;
+            return ptd;
+        }
+    }
+
+    return NULL;
+}
+
 void xhciScheduleIsoTDs(struct PCIController *hc)
 {
     struct PCIUnit *unit = hc->hc_Unit;
@@ -69,9 +90,9 @@ void xhciScheduleIsoTDs(struct PCIController *hc)
             trbflags |= TRBF_FLAG_ISP;
 
         BOOL explicit_frame = FALSE;
-        struct RTIsoNode *rtn = (struct RTIsoNode *)ioreq->iouh_DriverPrivate2;
-        if (rtn)
-            explicit_frame = (rtn->rtn_Flags & RTISO_FLAG_EXPLICIT_FRAME) != 0;
+        struct PTDNode *ptd = (struct PTDNode *)ioreq->iouh_DriverPrivate2;
+        if (ptd)
+            explicit_frame = (ptd->ptd_BufferReq.ubr_Frame != 0);
         else
             explicit_frame = (ioreq->iouh_Frame != 0);
 
@@ -90,6 +111,10 @@ void xhciScheduleIsoTDs(struct PCIController *hc)
 
             if (queued != -1) {
                 AddTail(&hc->hc_PeriodicTDQueue, (struct Node *) ioreq);
+                if (ptd) {
+                    ptd->ptd_Flags |= PTDF_ACTIVE;
+                    ptd->ptd_Flags &= ~PTDF_BUFFER_VALID;
+                }
                 txdone = TRUE;
             }
         }
@@ -139,6 +164,13 @@ WORD xhciInitIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
             goto fail;
         }
 
+        CopyMem(&rtn->rtn_IOReq, &ptd->ptd_IOReq, sizeof(ptd->ptd_IOReq));
+        ptd->ptd_IOReq.iouh_DriverPrivate1 = NULL;
+        ptd->ptd_IOReq.iouh_DriverPrivate2 = NULL;
+        ptd->ptd_IOReq.iouh_Req.io_Message.mn_Node.ln_Succ = NULL;
+        ptd->ptd_IOReq.iouh_Req.io_Message.mn_Node.ln_Pred = NULL;
+        ptd->ptd_RTIsoNode = rtn;
+
         rtn->rtn_PTDs[idx] = ptd;
     }
 
@@ -155,30 +187,37 @@ fail:
 WORD xhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
 {
     struct IOUsbHWReq *ioreq = pciusbIsoGetIOReq(rtn);
+    struct PTDNode *ptd = xhciNextIsoPTD(rtn);
     struct IOUsbHWRTIso *urti = rtn->rtn_RTIso;
     ULONG interval_uf;
 
     pciusbXHCIDebug("xHCI", DEBUGFUNCCOLOR_SET "%s()" DEBUGCOLOR_RESET" \n", __func__);
 
+    if (!ptd)
+        return UHIOERR_NAKTIMEOUT;
+
+    struct IOUsbHWBufferReq *bufreq = &ptd->ptd_BufferReq;
+    *bufreq = rtn->rtn_BufferReq;
+
     if (urti) {
         if (ioreq->iouh_Dir == UHDIR_IN) {
             if (urti->urti_InReqHook)
-                CallHookPkt(urti->urti_InReqHook, rtn, &rtn->rtn_BufferReq);
+                CallHookPkt(urti->urti_InReqHook, rtn, bufreq);
         } else {
             if (urti->urti_OutReqHook)
-                CallHookPkt(urti->urti_OutReqHook, rtn, &rtn->rtn_BufferReq);
+                CallHookPkt(urti->urti_OutReqHook, rtn, bufreq);
         }
     } else {
-        rtn->rtn_BufferReq.ubr_Buffer = ioreq->iouh_Data;
-        rtn->rtn_BufferReq.ubr_Length = ioreq->iouh_Length;
-        rtn->rtn_BufferReq.ubr_Frame = ioreq->iouh_Frame;
-        rtn->rtn_BufferReq.ubr_Flags = 0;
+        bufreq->ubr_Buffer = ioreq->iouh_Data;
+        bufreq->ubr_Length = ioreq->iouh_Length;
+        bufreq->ubr_Frame = ioreq->iouh_Frame;
+        bufreq->ubr_Flags = 0;
     }
 
-    if (!rtn->rtn_BufferReq.ubr_Length)
-        rtn->rtn_BufferReq.ubr_Length = ioreq->iouh_Length;
+    if (!bufreq->ubr_Length)
+        bufreq->ubr_Length = ioreq->iouh_Length;
 
-    if (rtn->rtn_BufferReq.ubr_Frame)
+    if (bufreq->ubr_Frame)
         rtn->rtn_Flags |= RTISO_FLAG_EXPLICIT_FRAME;
     else
         rtn->rtn_Flags &= ~RTISO_FLAG_EXPLICIT_FRAME;
@@ -206,18 +245,19 @@ WORD xhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
             interval_uf = 1;
     }
 
-    if (!rtn->rtn_BufferReq.ubr_Frame) {
+    if (!bufreq->ubr_Frame) {
         /*
          * xHCI needs ISO TDs queued sufficiently ahead of the service
          * interval. A single-interval lead is often too tight on VMware.
          */
         ULONG lead = interval_uf * 2;
         ULONG next = rtn->rtn_NextFrame ? rtn->rtn_NextFrame : (hc->hc_FrameCounter + lead);
-        rtn->rtn_BufferReq.ubr_Frame = next;
+        bufreq->ubr_Frame = next;
     }
-    rtn->rtn_NextFrame = rtn->rtn_BufferReq.ubr_Frame + interval_uf;
+    rtn->rtn_NextFrame = bufreq->ubr_Frame + interval_uf;
 
-    rtn->rtn_NextPTD = 0;
+    ptd->ptd_FrameIdx = bufreq->ubr_Frame;
+    ptd->ptd_Flags |= PTDF_BUFFER_VALID;
 
     return RC_OK;
 }
@@ -229,18 +269,32 @@ void xhciStartIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
     if (!rtn->rtn_PTDs || !rtn->rtn_PTDCount)
         return;
 
-    /* Use the IOReq stored in the RTIso node for the actual transfer. */
-    struct IOUsbHWReq *ioreq = &rtn->rtn_IOReq;
+    struct PTDNode *ptd = NULL;
+    for (UWORD idx = 0; idx < rtn->rtn_PTDCount; idx++) {
+        struct PTDNode *candidate = rtn->rtn_PTDs[idx];
+        if (candidate && (candidate->ptd_Flags & PTDF_BUFFER_VALID) &&
+            !(candidate->ptd_Flags & PTDF_ACTIVE)) {
+            ptd = candidate;
+            break;
+        }
+    }
 
-    if (!rtn->rtn_BufferReq.ubr_Buffer || !rtn->rtn_BufferReq.ubr_Length)
+    if (!ptd)
         return;
 
-    ioreq->iouh_Data = rtn->rtn_BufferReq.ubr_Buffer;
-    ioreq->iouh_Length = rtn->rtn_BufferReq.ubr_Length;
-    ioreq->iouh_Frame = rtn->rtn_BufferReq.ubr_Frame;
+    /* Use the IOReq stored per PTD for the actual transfer. */
+    struct IOUsbHWReq *ioreq = &ptd->ptd_IOReq;
+
+    if (!ptd->ptd_BufferReq.ubr_Buffer || !ptd->ptd_BufferReq.ubr_Length)
+        return;
+
+    ioreq->iouh_Data = ptd->ptd_BufferReq.ubr_Buffer;
+    ioreq->iouh_Length = ptd->ptd_BufferReq.ubr_Length;
+    ioreq->iouh_Frame = ptd->ptd_BufferReq.ubr_Frame;
     ioreq->iouh_Req.io_Command = UHCMD_ISOXFER;
     ioreq->iouh_Req.io_Error = 0;
-    ioreq->iouh_DriverPrivate2 = rtn;
+    ioreq->iouh_Actual = 0;
+    ioreq->iouh_DriverPrivate2 = ptd;
 
     if (!ioreq->iouh_DriverPrivate1) {
         struct pciusbXHCIIODevPrivate *driprivate = NULL;
@@ -262,13 +316,23 @@ void xhciStopIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
         return;
 
     Disable();
-    xhciFreePeriodicContext(hc, hc->hc_Unit, &rtn->rtn_IOReq);
+    for (UWORD idx = 0; idx < rtn->rtn_PTDCount; idx++) {
+        struct PTDNode *ptd = rtn->rtn_PTDs[idx];
+        if (ptd && ptd->ptd_IOReq.iouh_DriverPrivate1)
+            xhciFreePeriodicContext(hc, hc->hc_Unit, &ptd->ptd_IOReq);
+    }
     Enable();
 
     if (rtn->rtn_BounceBuffer && rtn->rtn_BounceBuffer != rtn->rtn_BufferReq.ubr_Buffer) {
         usbReleaseBuffer(rtn->rtn_BounceBuffer, rtn->rtn_BufferReq.ubr_Buffer,
                          rtn->rtn_BufferReq.ubr_Length, rtn->rtn_IOReq.iouh_Dir);
         rtn->rtn_BounceBuffer = NULL;
+    }
+
+    for (UWORD idx = 0; idx < rtn->rtn_PTDCount; idx++) {
+        struct PTDNode *ptd = rtn->rtn_PTDs[idx];
+        if (ptd)
+            ptd->ptd_Flags &= ~(PTDF_ACTIVE | PTDF_BUFFER_VALID);
     }
 }
 

--- a/rom/usb/pciusb/xhcichip_schedule.c
+++ b/rom/usb/pciusb/xhcichip_schedule.c
@@ -291,8 +291,7 @@ BOOL xhciActivateEndpointTransfer(struct PCIController *hc, struct PCIUnit *unit
 
     Disable();
     if ((ioreq->iouh_DriverPrivate1 = driprivate) != NULL) {
-        if (ioreq->iouh_Req.io_Command != UHCMD_ISOXFER)
-            unit->hu_DevBusyReq[devadrep] = ioreq;
+        unit->hu_DevBusyReq[devadrep] = ioreq;
 
         if (driprivate->dpDevice) {
             *epringOut = driprivate->dpDevice->dc_EPAllocs[driprivate->dpEPID].dmaa_Ptr;

--- a/rom/usb/pciusb/xhcichip_schedule.c
+++ b/rom/usb/pciusb/xhcichip_schedule.c
@@ -291,7 +291,8 @@ BOOL xhciActivateEndpointTransfer(struct PCIController *hc, struct PCIUnit *unit
 
     Disable();
     if ((ioreq->iouh_DriverPrivate1 = driprivate) != NULL) {
-        unit->hu_DevBusyReq[devadrep] = ioreq;
+        if (ioreq->iouh_Req.io_Command != UHCMD_ISOXFER)
+            unit->hu_DevBusyReq[devadrep] = ioreq;
 
         if (driprivate->dpDevice) {
             *epringOut = driprivate->dpDevice->dc_EPAllocs[driprivate->dpEPID].dmaa_Ptr;


### PR DESCRIPTION
### Motivation
- Add multi-buffer (per-PTD) support for xHCI realtime isochronous transfers to allow multiple in-flight ISO TDs similar to the Deneb driver.
- Prevent overwriting a single `rtn_BufferReq` when queuing multiple scheduled frames and keep at least two frames scheduled ahead to avoid underruns on tight timing (VMware etc.).
- Ensure queued ISO TDs are submitted per-slot instead of relying on a single RTIso IOReq, and requeue new TDs before the last microframe completes.

### Description
- Add per-PTD state to `struct PTDNode` in `pciusb.h` including `ptd_IOReq`, `ptd_BufferReq` and `ptd_RTIsoNode` to track buffer/IO state per slot.
- Implement `xhciNextIsoPTD()` and update `xhciQueueIsochIO()` to copy the scheduled buffer into the selected PTD's `ptd_BufferReq` and mark the PTD as `PTDF_BUFFER_VALID` instead of overwriting a shared `rtn_BufferReq`.
- Change `xhciStartIsochIO()` and `xhciScheduleIsoTDs()` to use per-PTD `IOReq`/buffer when submitting, set/clear `PTDF_ACTIVE` and `PTDF_BUFFER_VALID`, and queue distinct TRBs per PTD.
- Update periodic completion handling (`xhciHandleFinishedTDs()` in `xhcichip.c`) to treat `iouh_DriverPrivate2` as a `PTDNode`, invoke RTIso hooks with the PTD buffer, clear PTD flags on completion, and requeue/start additional PTDs until a `target` (two when available) are pending; also change `cmdStartRTIso()` to start all prefetched xHCI ISO TDs.

### Testing
- No automated tests were run for this change.
- Changes were compiled into the local working tree and staged as source edits, but no unit or integration test harness was executed.
- Runtime/driver integration testing on actual hardware or emulation was not performed as part of this PR.
- Review and static checks are recommended before running live USB RTIso workloads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958207c26ac83298e4fcb4fed09411c)