### PR TITLE
Sync sound.datatype prefs load/save timing and MUI checkbox handling

### DIFF
--- a/workbench/devs/AHI/AHI/ahi.c
+++ b/workbench/devs/AHI/AHI/ahi.c
@@ -221,6 +221,8 @@ void NewSettings(char *name)
     globalprefs.ahigp_AntiClickTime    = 0;
     globalprefs.ahigp_ScaleMode        = AHI_SCALE_FIXED_0_DB;
 
+    LoadSoundDT41Prefs();
+
     UnitList = GetUnits(name);
     Units = List2Array((struct List *) UnitList);
 

--- a/workbench/devs/AHI/AHI/gui_mui.c
+++ b/workbench/devs/AHI/AHI/gui_mui.c
@@ -117,6 +117,9 @@ enum actionIDs {
     SHOWID_INPUT, SHOWID_OUTPUT,
 
     ACTID_PLAY,
+#if defined(__AROS__)
+    ACTID_USEFORSDT,
+#endif
 
     ACTID_DEBUG, ACTID_SURROUND, ACTID_ECHO, ACTID_CLIPMV,
     ACTID_CPULIMIT, SHOWID_CPULIMIT,
@@ -270,6 +273,9 @@ static Object *MUIWindow, *MUIList, *MUIInfos, *MUIUnit;
 static Object *MUIFreq, *MUIChannels, *MUIOutvol, *MUIMonvol, *MUIGain, *MUIInput, *MUIOutput;
 static Object *MUILFreq, *MUILChannels, *MUILOutvol, *MUILMonvol, *MUILGain, *MUILInput, *MUILOutput, *MUIPlay;
 static Object *MUIDebug, *MUIEcho, *MUISurround, *MUIClipvol, *MUICpu, *MUIACTime, *MUIScalemode;
+#if defined(__AROS__)
+static Object *MUIUseforSDT;
+#endif
 
 SIPTR xget(Object *obj, ULONG attribute)
 {
@@ -415,6 +421,22 @@ static void GUINewMode(void)
     }
     set(MUILOutput, MUIA_Text_Contents, (IPTR) getOutput());
 
+#if defined(__AROS__)
+    if(MUIUseforSDT != NULL) {
+        const struct SoundDT41Prefs *prefs = GetSoundDT41Prefs();
+        struct UnitNode *unit = (struct UnitNode *) GetNode(state.UnitSelected, UnitList);
+        BOOL match = FALSE;
+
+        if(unit != NULL && prefs->has_ahimodeid &&
+           prefs->ahimodeid == unit->prefs.ahiup_AudioMode) {
+            match = TRUE;
+        }
+
+        set(MUIUseforSDT, MUIA_NoNotify, TRUE);
+        set(MUIUseforSDT, MUIA_Selected, match);
+        set(MUIUseforSDT, MUIA_NoNotify, FALSE);
+    }
+#endif
 
     set(MUIPlay, MUIA_Disabled, getAudioMode() == AHI_INVALID_ID);
 }
@@ -541,7 +563,7 @@ BOOL BuildGUI(char *screenname)
     Object *MUITFreq, *MUITChannels, *MUITOutvol, *MUITMonvol, *MUITGain, *MUITInput, *MUITOutput, *MUITDebug, *MUITEcho,
            *MUITSurround, *MUITClipvol, *MUITCpu, *MUITACTime, *MUITScalemode;
 #if defined(__AROS__)
-    Object *MUIUseforSDT, *MUILUseforSDT;
+    Object *MUILUseforSDT;
 #endif
 
     D(bug("[AHI:Prefs] %s()\n", __func__);)
@@ -785,6 +807,10 @@ BOOL BuildGUI(char *screenname)
                  MUIV_TriggerValue);
         DoMethod(MUIOutput, MUIM_Notify, MUIA_Numeric_Value, MUIV_EveryTime, MUIV_Notify_Self, 3, MUIM_CallHook, &hookSlider,
                  MUIV_TriggerValue);
+#if defined(__AROS__)
+        DoMethod(MUIUseforSDT, MUIM_Notify, MUIA_Selected, MUIV_EveryTime, MUIApp, 2, MUIM_Application_ReturnID,
+                 ACTID_USEFORSDT);
+#endif
         set(MUIWindow, MUIA_Window_Open, TRUE);
         GUINewUnit();
         return TRUE;
@@ -976,6 +1002,21 @@ void EventLoop(void)
             GUINewMode();
             break;
 
+#if defined(__AROS__)
+        case ACTID_USEFORSDT: {
+            IPTR selected = FALSE;
+            struct UnitNode *unit;
+
+            get(MUIUseforSDT, MUIA_Selected, &selected);
+            unit = (struct UnitNode *) GetNode(state.UnitSelected, UnitList);
+            if(unit != NULL) {
+                SetSoundDT41UseMode(selected, unit->prefs.ahiup_AudioMode);
+            } else {
+                SetSoundDT41UseMode(FALSE, AHI_INVALID_ID);
+            }
+            break;
+        }
+#endif
         case ACTID_PLAY: {
             int              unit_id;
             struct UnitNode *unit;
@@ -1026,4 +1067,3 @@ void EventLoop(void)
         }
     }
 }
-

--- a/workbench/devs/AHI/AHI/support.c
+++ b/workbench/devs/AHI/AHI/support.c
@@ -50,7 +50,11 @@
 static BOOL AddUnit(struct List *, int);
 static void FillUnitName(struct UnitNode *);
 
+#define SOUND_DT41_VAR "datatypes/sounddt41.prefs"
+
 struct AHIGlobalPrefs     globalprefs;
+static struct SoundDT41Prefs sounddtprefs;
+static STRPTR sounddtprefs_raw;
 
 #ifdef __AMIGAOS4__
 struct Library           *GadToolsBase = NULL;
@@ -135,6 +139,317 @@ static struct DiskObject projIcon = {
     NULL,                           /* Tool Window */
     4096                            /* Stack Size */
 };
+
+static BOOL IsSoundDTSeparator(char c)
+{
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ',';
+}
+
+static BOOL ParseSoundDTHex(const char *value, size_t len, ULONG *out_value)
+{
+    char buffer[32];
+    char *end = NULL;
+
+    if(len == 0 || len >= sizeof(buffer)) {
+        return FALSE;
+    }
+
+    CopyMem(value, buffer, len);
+    buffer[len] = '\0';
+
+    *out_value = strtoul(buffer, &end, 0);
+    return end != buffer;
+}
+
+static STRPTR LoadSoundDT41Var(LONG *out_len)
+{
+    TEXT dummy[4];
+    LONG size;
+    LONG ret;
+    STRPTR buffer;
+
+    ret = GetVar(SOUND_DT41_VAR, dummy, sizeof(dummy), GVF_GLOBAL_ONLY);
+    if(ret == -1) {
+        return NULL;
+    }
+
+    size = IoErr();
+    if(size <= 0) {
+        size = ret;
+    }
+
+    if(size <= 0) {
+        return NULL;
+    }
+
+    buffer = AllocVec(size + 2, MEMF_ANY);
+    if(buffer == NULL) {
+        return NULL;
+    }
+
+    buffer[size] = '\0';
+    buffer[size + 1] = '\0';
+
+    if(GetVar(SOUND_DT41_VAR, buffer, size + 1, GVF_GLOBAL_ONLY) == -1) {
+        FreeVec(buffer);
+        return NULL;
+    }
+
+    if(out_len != NULL) {
+        *out_len = size;
+    }
+
+    return buffer;
+}
+
+static STRPTR RewriteSoundDT41Prefs(const char *prefs, ULONG mode_id, BOOL use_mode)
+{
+    size_t prefs_len = strlen(prefs);
+    size_t buffer_len = prefs_len + 64;
+    STRPTR out = AllocVec(buffer_len, MEMF_ANY);
+    const char *cursor = prefs;
+    char *dst;
+    BOOL saw_ahimodeid = FALSE;
+    BOOL saw_force = FALSE;
+    BOOL skip_mode_value = FALSE;
+
+    if(out == NULL) {
+        return NULL;
+    }
+
+    dst = out;
+
+    while(*cursor != '\0') {
+        const char *token_start;
+        size_t token_len;
+
+        if(IsSoundDTSeparator(*cursor)) {
+            *dst++ = *cursor++;
+            continue;
+        }
+
+        token_start = cursor;
+        while(*cursor != '\0' && !IsSoundDTSeparator(*cursor)) {
+            cursor++;
+        }
+        token_len = (size_t)(cursor - token_start);
+
+        if(skip_mode_value) {
+            skip_mode_value = FALSE;
+            if(!use_mode) {
+                continue;
+            }
+        }
+
+        if(token_len == 9 && Strnicmp(token_start, "AHIMODEID", 9) == 0) {
+            if(use_mode) {
+                char replacement[32];
+                int written = snprintf(replacement, sizeof(replacement), "AHIMODEID=0x%08lx", mode_id);
+
+                CopyMem(replacement, dst, written);
+                dst += written;
+                saw_ahimodeid = TRUE;
+            }
+            skip_mode_value = TRUE;
+            continue;
+        }
+
+        if(token_len >= 9 && Strnicmp(token_start, "AHIMODEID", 9) == 0 &&
+           (token_len == 9 || token_start[9] == '=')) {
+            if(use_mode) {
+                char replacement[32];
+                int written = snprintf(replacement, sizeof(replacement), "AHIMODEID=0x%08lx", mode_id);
+
+                CopyMem(replacement, dst, written);
+                dst += written;
+                saw_ahimodeid = TRUE;
+            }
+            continue;
+        }
+
+        if(token_len == 12 && Strnicmp(token_start, "FORCEAHIMODE", 12) == 0) {
+            saw_force = TRUE;
+            if(!use_mode) {
+                continue;
+            }
+        } else if(token_len == 3 && Strnicmp(token_start, "FAM", 3) == 0) {
+            saw_force = TRUE;
+            if(!use_mode) {
+                continue;
+            }
+        }
+
+        CopyMem(token_start, dst, token_len);
+        dst += token_len;
+    }
+
+    if(use_mode && !saw_ahimodeid) {
+        dst += sprintf(dst, "%sAHIMODEID=0x%08lx", (dst > out && !IsSoundDTSeparator(dst[-1])) ? " " : "", mode_id);
+    }
+
+    if(use_mode && !saw_force) {
+        dst += sprintf(dst, "%sFORCEAHIMODE", (dst > out && !IsSoundDTSeparator(dst[-1])) ? " " : "");
+    }
+
+    *dst = '\0';
+    return out;
+}
+
+static BOOL ReadSoundDT41Prefs(struct SoundDT41Prefs *prefs, STRPTR buffer)
+{
+    BOOL expect_mode = FALSE;
+
+    if(prefs == NULL) {
+        return FALSE;
+    }
+
+    memset(prefs, 0, sizeof(*prefs));
+
+    if(buffer == NULL) {
+        return FALSE;
+    }
+
+    prefs->has_prefs = TRUE;
+
+    {
+        const char *cursor = buffer;
+        while(*cursor != '\0') {
+            const char *token_start;
+            size_t token_len;
+
+            while(*cursor != '\0' && IsSoundDTSeparator(*cursor)) {
+                cursor++;
+            }
+
+            if(*cursor == '\0') {
+                break;
+            }
+
+            token_start = cursor;
+            while(*cursor != '\0' && !IsSoundDTSeparator(*cursor)) {
+                cursor++;
+            }
+            token_len = (size_t)(cursor - token_start);
+
+            if(expect_mode) {
+                if(ParseSoundDTHex(token_start, token_len, &prefs->ahimodeid)) {
+                    prefs->has_ahimodeid = TRUE;
+                }
+                expect_mode = FALSE;
+                continue;
+            }
+
+            if(token_len == 3 && Strnicmp(token_start, "AHI", 3) == 0) {
+                prefs->ahi_present = TRUE;
+                continue;
+            }
+
+            if(token_len == 12 && Strnicmp(token_start, "FORCEAHIMODE", 12) == 0) {
+                prefs->force_ahimode = TRUE;
+                continue;
+            }
+
+            if(token_len == 3 && Strnicmp(token_start, "FAM", 3) == 0) {
+                prefs->force_ahimode = TRUE;
+                continue;
+            }
+
+            if(token_len == 9 && Strnicmp(token_start, "AHIMODEID", 9) == 0) {
+                expect_mode = TRUE;
+                continue;
+            }
+
+            if(token_len > 9 && Strnicmp(token_start, "AHIMODEID", 9) == 0 && token_start[9] == '=') {
+                if(ParseSoundDTHex(token_start + 10, token_len - 10, &prefs->ahimodeid)) {
+                    prefs->has_ahimodeid = TRUE;
+                }
+            }
+        }
+    }
+
+    return TRUE;
+}
+
+BOOL LoadSoundDT41Prefs(void)
+{
+    STRPTR buffer = NULL;
+
+    if(sounddtprefs_raw != NULL) {
+        FreeVec(sounddtprefs_raw);
+        sounddtprefs_raw = NULL;
+    }
+
+    memset(&sounddtprefs, 0, sizeof(sounddtprefs));
+
+    buffer = LoadSoundDT41Var(NULL);
+    if(buffer == NULL) {
+        return FALSE;
+    }
+
+    ReadSoundDT41Prefs(&sounddtprefs, buffer);
+    sounddtprefs_raw = buffer;
+    return TRUE;
+}
+
+const struct SoundDT41Prefs *GetSoundDT41Prefs(void)
+{
+    return &sounddtprefs;
+}
+
+void SetSoundDT41UseMode(BOOL use_mode, ULONG mode_id)
+{
+    if(use_mode && mode_id != AHI_INVALID_ID) {
+        sounddtprefs.has_prefs = TRUE;
+        sounddtprefs.has_ahimodeid = TRUE;
+        sounddtprefs.force_ahimode = TRUE;
+        sounddtprefs.ahimodeid = mode_id;
+        return;
+    }
+
+    sounddtprefs.has_ahimodeid = FALSE;
+    sounddtprefs.force_ahimode = FALSE;
+}
+
+BOOL UpdateSoundDT41Prefs(BOOL save_to_envarc)
+{
+    STRPTR updated = NULL;
+    BOOL success;
+    ULONG flags = GVF_GLOBAL_ONLY;
+
+    if(sounddtprefs.has_ahimodeid && sounddtprefs.ahimodeid == AHI_INVALID_ID) {
+        return FALSE;
+    }
+
+    if(sounddtprefs_raw != NULL) {
+        updated = RewriteSoundDT41Prefs(sounddtprefs_raw,
+                                        sounddtprefs.ahimodeid,
+                                        sounddtprefs.has_ahimodeid);
+    } else if(sounddtprefs.has_ahimodeid) {
+        updated = AllocVec(64, MEMF_ANY);
+        if(updated != NULL) {
+            sprintf(updated, "AHI AHIMODEID=0x%08lx FORCEAHIMODE", sounddtprefs.ahimodeid);
+        }
+    } else {
+        return TRUE;
+    }
+
+    if(updated == NULL) {
+        return FALSE;
+    }
+
+    if(save_to_envarc) {
+        flags |= GVF_SAVE_VAR;
+    }
+
+    success = SetVar(SOUND_DT41_VAR, updated, strlen(updated), flags);
+
+    if(sounddtprefs_raw != NULL) {
+        FreeVec(sounddtprefs_raw);
+    }
+    sounddtprefs_raw = updated;
+
+    return success;
+}
 
 
 /******************************************************************************
@@ -758,6 +1073,12 @@ BOOL SaveSettings(char *name, struct List *list)
         }
         FreeIFF(iff);
     }
+
+    if(success && name != NULL &&
+       (strcmp(name, ENVFILE) == 0 || strcmp(name, ENVARCFILE) == 0)) {
+        UpdateSoundDT41Prefs(strcmp(name, ENVARCFILE) == 0);
+    }
+
     return success;
 }
 

--- a/workbench/devs/AHI/AHI/support.h
+++ b/workbench/devs/AHI/AHI/support.h
@@ -30,6 +30,14 @@
 
 extern struct AHIGlobalPrefs globalprefs;
 
+struct SoundDT41Prefs {
+    BOOL has_prefs;
+    BOOL ahi_present;
+    BOOL force_ahimode;
+    BOOL has_ahimodeid;
+    ULONG ahimodeid;
+};
+
 BOOL Initialize(void);
 void CleanUp(void);
 
@@ -42,6 +50,10 @@ BOOL SaveSettings(char *, struct List *);
 BOOL WriteIcon(char *);
 void FreeList(struct List *);
 struct Node *GetNode(int, struct List *);
+BOOL LoadSoundDT41Prefs(void);
+const struct SoundDT41Prefs *GetSoundDT41Prefs(void);
+void SetSoundDT41UseMode(BOOL use_mode, ULONG mode_id);
+BOOL UpdateSoundDT41Prefs(BOOL save_to_envarc);
 
 BOOL PlaySound(struct AHIUnitPrefs *);
 


### PR DESCRIPTION
### Motivation
- Ensure `datatypes/sounddt41.prefs` is read only when AHI prefs are loaded and reused for saves to avoid spurious reads/writes. 
- Let the MUI "use for SDT" checkbox drive whether the selected unit's AHI mode is stored in the sound datatype prefs. 
- Preserve existing sound.datatype tokens when updating `AHIMODEID` and only insert `FORCEAHIMODE` when the mode is being used. 
- Prevent the checkbox state update from triggering notifications when the UI is refreshed to avoid clearing the stored mode unintentionally. 

### Description
- Added `struct SoundDT41Prefs` and new APIs in `support.h`: `LoadSoundDT41Prefs`, `GetSoundDT41Prefs`, `SetSoundDT41UseMode`, and `UpdateSoundDT41Prefs` to manage cached sound.dt prefs. 
- Implemented parsing, loading, rewriting and update logic in `support.c` (helpers: `LoadSoundDT41Var`, `ParseSoundDTHex`, `ReadSoundDT41Prefs`, `RewriteSoundDT41Prefs`, plus the cache variables `sounddtprefs` and `sounddtprefs_raw`). 
- Call `LoadSoundDT41Prefs()` when AHI prefs are read (`ahi.c`) and call `UpdateSoundDT41Prefs()` from `SaveSettings()` to save the cached value for `ENV:`/`ENVARC:` flows. 
- Wire the AROS MUI checkbox into the GUI (`gui_mui.c`): add `ACTID_USEFORSDT`, set checkbox state from `GetSoundDT41Prefs()`, suppress notifications during UI updates using `MUIA_NoNotify`, and handle checkbox notifications to call `SetSoundDT41UseMode()` for storing or clearing the mode ID. 

### Testing
- No automated tests were executed for this change. 
- CI/build verification was not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959382d06748329a9ce6f2faf33daa4)