### PR TITLE
EHCI: ensure schedule allocations stay within a single 4GB segment with low-memory fallback

### DIFF
--- a/rom/usb/pciusb/ehcichip.c
+++ b/rom/usb/pciusb/ehcichip.c
@@ -8,6 +8,7 @@
 
 #include <hidd/pci.h>
 #include <utility/hooks.h>
+#include <exec/memory.h>
 
 #include <devices/usb_hub.h>
 
@@ -105,6 +106,31 @@ static inline void ehciReleaseDMABuffer(APTR dmabuffer, APTR original, ULONG len
     (void)length;
     (void)dir;
 #endif
+}
+
+static BOOL ehciScheduleSegmentValid(struct PCIController *hc, APTR base, ULONG size, ULONG *segment)
+{
+#if __WORDSIZE == 64
+    UQUAD phys_base = (UQUAD)(IPTR)pciGetPhysical(hc, base);
+    UQUAD phys_end = phys_base + (UQUAD)size - 1;
+    ULONG seg = (ULONG)(phys_base >> 32);
+
+    if ((phys_end >> 32) != seg) {
+        return FALSE;
+    }
+
+    if (segment) {
+        *segment = seg;
+    }
+#else
+    (void)hc;
+    (void)base;
+    (void)size;
+    if (segment) {
+        *segment = 0;
+    }
+#endif
+    return TRUE;
 }
 
 static void ehciFillScatterGather(struct PCIController *hc, struct EhciHCPrivate *ehcihcp,
@@ -1710,6 +1736,9 @@ BOOL ehciInit(struct PCIController *hc, struct PCIUnit *hu)
     ULONG timeout;
     ULONG tmp;
     ULONG fls;
+    ULONG schedule_bytes;
+    ULONG schedule_segment = 0;
+    BOOL schedule_ok = TRUE;
 
     ULONG cnt;
 
@@ -1778,6 +1807,12 @@ BOOL ehciInit(struct PCIController *hc, struct PCIUnit *hu)
         Frame list size was determined from HCCPARAMS/USBCMD when programmable,
         falling back to EHCI_FRAMELIST_SIZE when not.
     */
+    schedule_bytes = sizeof(ULONG) * ehcihcp->ehc_FrameListSize;
+    schedule_bytes += sizeof(struct EhciQH) * EHCI_QH_POOLSIZE;
+    schedule_bytes += sizeof(struct EhciTD) * EHCI_TD_POOLSIZE;
+    schedule_bytes += sizeof(struct EhciITD) * EHCI_ITD_POOLSIZE;
+    schedule_bytes += sizeof(struct EhciSiTD) * EHCI_SITD_POOLSIZE;
+
     hc->hc_PCIMem.me_Length = sizeof(ULONG) * ehcihcp->ehc_FrameListSize + EHCI_FRAMELIST_ALIGNMENT + 1;
     hc->hc_PCIMem.me_Length += sizeof(struct EhciQH) * EHCI_QH_POOLSIZE;
     hc->hc_PCIMem.me_Length += sizeof(struct EhciTD) * EHCI_TD_POOLSIZE;
@@ -1789,15 +1824,41 @@ BOOL ehciInit(struct PCIController *hc, struct PCIUnit *hu)
     */
     memptr = ALLOCPCIMEM(hc, hc->hc_PCIDriverObject, hc->hc_PCIMem.me_Length);
     hc->hc_PCIMem.me_Un.meu_Addr = (APTR) memptr;
+    hc->hc_PCIMemIsExec = FALSE;
 
     if(memptr) {
-        // PhysicalAddress - VirtualAdjust = VirtualAddress
-        // VirtualAddress  + VirtualAdjust = PhysicalAddress
-        hc->hc_PCIVirtualAdjust = pciGetPhysical(hc, memptr) - (APTR)memptr;
-        pciusbEHCIDebug("EHCI", "VirtualAdjust 0x%08lx\n", hc->hc_PCIVirtualAdjust);
-
         // align memory
         memptr = (UBYTE *) ((((IPTR) hc->hc_PCIMem.me_Un.meu_Addr) + EHCI_FRAMELIST_ALIGNMENT) & (~EHCI_FRAMELIST_ALIGNMENT));
+#if __WORDSIZE == 64
+        schedule_ok = ehciScheduleSegmentValid(hc, memptr, schedule_bytes, &schedule_segment);
+        if(schedule_ok && !(hccparams & EHCF_64BITS) && schedule_segment != 0) {
+            schedule_ok = FALSE;
+        }
+        if(!schedule_ok) {
+            pciusbWarn("EHCI", "Schedule allocation crosses 4GB boundary, retrying in low memory\n");
+            FREEPCIMEM(hc, hc->hc_PCIDriverObject, hc->hc_PCIMem.me_Un.meu_Addr);
+            hc->hc_PCIMem.me_Un.meu_Addr = NULL;
+            hc->hc_PCIMemIsExec = TRUE;
+            memptr = AllocMem(hc->hc_PCIMem.me_Length, MEMF_31BIT | MEMF_CLEAR);
+            hc->hc_PCIMem.me_Un.meu_Addr = (APTR)memptr;
+            if(memptr) {
+                memptr = (UBYTE *) ((((IPTR) hc->hc_PCIMem.me_Un.meu_Addr) + EHCI_FRAMELIST_ALIGNMENT) & (~EHCI_FRAMELIST_ALIGNMENT));
+                schedule_ok = ehciScheduleSegmentValid(hc, memptr, schedule_bytes, &schedule_segment);
+                if(schedule_ok && !(hccparams & EHCF_64BITS) && schedule_segment != 0) {
+                    schedule_ok = FALSE;
+                }
+            }
+        }
+#endif
+        if(!memptr || !schedule_ok) {
+            goto init_fail;
+        }
+
+        // PhysicalAddress - VirtualAdjust = VirtualAddress
+        // VirtualAddress  + VirtualAdjust = PhysicalAddress
+        hc->hc_PCIVirtualAdjust = pciGetPhysical(hc, hc->hc_PCIMem.me_Un.meu_Addr) - (APTR)hc->hc_PCIMem.me_Un.meu_Addr;
+        pciusbEHCIDebug("EHCI", "VirtualAdjust 0x%08lx\n", hc->hc_PCIVirtualAdjust);
+
         ehcihcp->ehc_EhciFrameList = (ULONG *) memptr;
         pciusbEHCIDebug("EHCI", "FrameListBase 0x%p\n", ehcihcp->ehc_EhciFrameList);
         memptr += sizeof(ULONG) * ehcihcp->ehc_FrameListSize;
@@ -2049,7 +2110,7 @@ BOOL ehciInit(struct PCIController *hc, struct PCIUnit *hu)
 #if __WORDSIZE == 64
         if(ehcihcp->ehc_64BitCapable) {
             IPTR framelistphys = (IPTR)pciGetPhysical(hc, ehcihcp->ehc_EhciFrameList);
-            WRITEREG32_LE(hc->hc_RegBase, EHCI_CTRLDSSEGMENT, AROS_LONG2LE((ULONG)(framelistphys >> 32)));
+            WRITEREG32_LE(hc->hc_RegBase, EHCI_CTRLDSSEGMENT, AROS_LONG2LE(schedule_segment));
             WRITEREG32_LE(hc->hc_RegBase, EHCI_PERIODICLIST, framelistphys);
         } else {
             WRITEREG32_LE(hc->hc_RegBase, EHCI_PERIODICLIST, (IPTR)pciGetPhysical(hc, ehcihcp->ehc_EhciFrameList));
@@ -2105,6 +2166,25 @@ BOOL ehciInit(struct PCIController *hc, struct PCIUnit *hu)
     /*
         FIXME: What would the appropriate debug level be?
     */
+init_fail:
+    if(hc->hc_PCIMem.me_Un.meu_Addr) {
+        if(hc->hc_PCIMemIsExec)
+            FreeMem(hc->hc_PCIMem.me_Un.meu_Addr, hc->hc_PCIMem.me_Length);
+        else
+            FREEPCIMEM(hc, hc->hc_PCIDriverObject, hc->hc_PCIMem.me_Un.meu_Addr);
+        hc->hc_PCIMem.me_Un.meu_Addr = NULL;
+        hc->hc_PCIMemIsExec = FALSE;
+    }
+    if(ehcihcp) {
+        if(ehcihcp->ehc_IsoAnchor)
+            FreeMem(ehcihcp->ehc_IsoAnchor, sizeof(ULONG) * ehcihcp->ehc_FrameListSize);
+        if(ehcihcp->ehc_IsoHead)
+            FreeMem(ehcihcp->ehc_IsoHead, sizeof(struct PTDNode *) * ehcihcp->ehc_FrameListSize);
+        if(ehcihcp->ehc_IsoTail)
+            FreeMem(ehcihcp->ehc_IsoTail, sizeof(struct PTDNode *) * ehcihcp->ehc_FrameListSize);
+        FreeMem(ehcihcp, sizeof(struct EhciHCPrivate));
+    }
+    hc->hc_CPrivate = NULL;
     KPRINTF(1000, "ehciInit returns FALSE...\n");
     return FALSE;
 }

--- a/rom/usb/pciusb/pciusb.h
+++ b/rom/usb/pciusb/pciusb.h
@@ -231,6 +231,7 @@ struct PCIController
     volatile APTR               hc_RegBase;
 
     struct MemEntry             hc_PCIMem;
+    BOOL                        hc_PCIMemIsExec;
     IPTR                        hc_PCIVirtualAdjust;
     IPTR                        hc_PCIIntLine;
     struct Interrupt            hc_PCIIntHandler;

--- a/rom/usb/pciusb/pciusb_arospci.c
+++ b/rom/usb/pciusb/pciusb_arospci.c
@@ -138,6 +138,7 @@ AROS_UFH3(void, pciEnumerator,
                 hc->hc_HCIType = hcitype;
                 hc->hc_PCIDeviceObject = pciDevice;
                 hc->hc_PCIIntLine = intline;
+                hc->hc_PCIMemIsExec = FALSE;
 
                 OOP_GetAttr(pciDevice, aHidd_PCIDevice_Driver, (IPTR *) &hc->hc_PCIDriverObject);
 
@@ -624,7 +625,12 @@ void pciFreeUnit(struct PCIUnit *hu)
     //FIXME: (x/e/o/u)hciFree routines actually ONLY stops the chip NOT free anything as below...
     ForeachNode(&hu->hu_Controllers, hc) {
         if(hc->hc_PCIMem.me_Un.meu_Addr) {
-            HIDD_PCIDriver_FreePCIMem(hc->hc_PCIDriverObject, hc->hc_PCIMem.me_Un.meu_Addr);
+            if (hc->hc_PCIMemIsExec) {
+                FreeMem(hc->hc_PCIMem.me_Un.meu_Addr, hc->hc_PCIMem.me_Length);
+                hc->hc_PCIMemIsExec = FALSE;
+            } else {
+                HIDD_PCIDriver_FreePCIMem(hc->hc_PCIDriverObject, hc->hc_PCIMem.me_Un.meu_Addr);
+            }
             hc->hc_PCIMem.me_Un.meu_Addr = NULL;
         }
     }


### PR DESCRIPTION
### Motivation
- Prevent EHCI schedule structures (frame list, QH/TD/ITD/SiTD pools) from spanning a 4 GB boundary which breaks pointer composition for 64-bit controllers. 
- Ensure `EHCI_CTRLDSSEGMENT` is programmed consistently from the validated segment used for the control/data structures. 
- Provide a robust fallback to a low-memory (31-bit/Exec) allocation when the default PCI-backed allocation cannot guarantee a single segment. 

### Description
- Added `ehciScheduleSegmentValid()` to verify that a candidate schedule buffer and its full size reside in a single 4 GB segment and return the segment index. 
- Compute `schedule_bytes` for all periodic/control structures and validate the initial `ALLOCPCIMEM()` buffer; if it crosses a 4 GB boundary retry using `AllocMem(..., MEMF_31BIT | MEMF_CLEAR)` and mark the allocation origin in `hc->hc_PCIMemIsExec`. 
- Programmed `EHCI_CTRLDSSEGMENT` from the validated `schedule_segment` instead of naively using the high 32 bits of the frame list pointer, and adjusted `hc_PCIVirtualAdjust` calculation to use the base allocation. 
- Added `hc_PCIMemIsExec` to `struct PCIController`, included proper freeing paths in `pciusb_arospci.c` and `ehcichip.c` to free Exec-allocated or driver-allocated memory appropriately, and included `<exec/memory.h>` where needed. 

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b96bcee1c832995d5ed9059c26648)