### PR TITLE
Fix UHCI RTIso scheduling, queue error handling, and hooks

### DIFF
--- a/rom/usb/pciusb/uhci/uhcichip.c
+++ b/rom/usb/pciusb/uhci/uhcichip.c
@@ -1705,8 +1705,21 @@ WORD uhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
         pciusbUHCIDebug("UHCI", "ISO schedule current=%ld next=%ld lead=%ld interval=%ld\n",
                         current_frame, bufreq->ubr_Frame, lead, interval);
     } else {
-        pciusbUHCIDebug("UHCI", "ISO schedule current=%ld interval=%ld\n",
-                        bufreq->ubr_Frame, interval);
+        ULONG current_frame;
+        ULONG lead = interval * 2;
+        LONG delta;
+
+        uhciUpdateFrameCounter(hc);
+        current_frame = hc->hc_FrameCounter;
+        delta = (LONG)bufreq->ubr_Frame - (LONG)current_frame;
+        if (delta <= 0 || delta >= (LONG)(UHCI_FRAMELIST_SIZE - lead)) {
+            bufreq->ubr_Frame = current_frame + lead;
+            pciusbUHCIDebug("UHCI", "ISO schedule adjusted current=%ld next=%ld lead=%ld interval=%ld\n",
+                            current_frame, bufreq->ubr_Frame, lead, interval);
+        } else {
+            pciusbUHCIDebug("UHCI", "ISO schedule current=%ld interval=%ld\n",
+                            bufreq->ubr_Frame, interval);
+        }
     }
     rtn->rtn_NextFrame = bufreq->ubr_Frame + interval;
 
@@ -1772,8 +1785,6 @@ void uhciHandleIsochTDs(struct PCIController *hc)
 
             if(urti) {
                 if(ioreq->iouh_Dir == UHDIR_IN) {
-                    if(urti->urti_InReqHook)
-                        CallHookPkt(urti->urti_InReqHook, rtn, &ptd->ptd_BufferReq);
                     if(urti->urti_InDoneHook)
                         CallHookPkt(urti->urti_InDoneHook, rtn, &ptd->ptd_BufferReq);
                 } else {
@@ -1796,8 +1807,21 @@ void uhciHandleIsochTDs(struct PCIController *hc)
                 uhciFreeIsochIO(hc, rtn);
                 pciusbFreeStdIsoNode(hc, rtn);
             } else if (urti) {
-                if (uhciQueueIsochIO(hc, rtn) == RC_OK)
+                UWORD pending = 0;
+                UWORD target = (rtn->rtn_PTDCount > 1) ? 2 : 1;
+
+                for (UWORD scan = 0; scan < rtn->rtn_PTDCount; scan++) {
+                    struct PTDNode *ptdscan = rtn->rtn_PTDs[scan];
+                    if (ptdscan && (ptdscan->ptd_Flags & (PTDF_ACTIVE | PTDF_BUFFER_VALID)))
+                        pending++;
+                }
+
+                while (pending < target) {
+                    if (uhciQueueIsochIO(hc, rtn) != RC_OK)
+                        break;
                     uhciStartIsochIO(hc, rtn);
+                    pending++;
+                }
             }
         }
 

--- a/rom/usb/pciusb/uhci/uhcichip.c
+++ b/rom/usb/pciusb/uhci/uhcichip.c
@@ -92,6 +92,7 @@ static void uhciInsertIsoPTD(struct PCIController *hc, struct PTDNode *ptd, ULON
     struct PTDNode *head = uhcihcp->uhc_IsoHead[slot];
     struct PTDNode *tail = uhcihcp->uhc_IsoTail[slot];
     struct UhciTD *utd = (struct UhciTD *)ptd->ptd_Descriptor;
+    ULONG prev_entry = READMEM32_LE(&uhcihcp->uhc_UhciFrameList[slot]);
 
     ptd->ptd_NextPTD = NULL;
     if(!head) {
@@ -100,6 +101,8 @@ static void uhciInsertIsoPTD(struct PCIController *hc, struct PTDNode *ptd, ULON
         uhcihcp->uhc_IsoHead[slot] = uhcihcp->uhc_IsoTail[slot] = ptd;
         WRITEMEM32_LE(&uhcihcp->uhc_UhciFrameList[slot], ptd->ptd_Phys);
         CacheClearE(&uhcihcp->uhc_UhciFrameList[slot], sizeof(ULONG), CACRF_ClearD);
+        pciusbUHCIDebug("UHCI", "ISO insert slot=%ld head prev=%08lx new=%08lx\n",
+                        slot, prev_entry, ptd->ptd_Phys);
     } else {
         struct UhciTD *tailtd = (struct UhciTD *)tail->ptd_Descriptor;
         ULONG nextphys = READMEM32_LE(&tailtd->utd_Link);
@@ -110,6 +113,8 @@ static void uhciInsertIsoPTD(struct PCIController *hc, struct PTDNode *ptd, ULON
         CacheClearE(tailtd, sizeof(*tailtd), CACRF_ClearD);
         tail->ptd_NextPTD = ptd;
         uhcihcp->uhc_IsoTail[slot] = ptd;
+        pciusbUHCIDebug("UHCI", "ISO insert slot=%ld tail prev=%08lx new=%08lx\n",
+                        slot, nextphys, ptd->ptd_Phys);
     }
 
     CacheClearE(utd, sizeof(*utd), CACRF_ClearD);
@@ -1659,6 +1664,7 @@ WORD uhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
     struct PTDNode *ptd = uhciNextIsoPTD(rtn);
     struct IOUsbHWRTIso *urti = rtn->rtn_RTIso;
     ULONG interval;
+    BOOL explicit_frame = FALSE;
 
     pciusbUHCIDebug("UHCI", "%s(0x%p, 0x%p)\n", __func__, hc, rtn);
     pciusbUHCIDebug("UHCI", "%s: IOReq 0x%p\n", __func__, ioreq);
@@ -1668,6 +1674,7 @@ WORD uhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
 
     struct IOUsbHWBufferReq *bufreq = &ptd->ptd_BufferReq;
     *bufreq = rtn->rtn_BufferReq;
+    explicit_frame = (bufreq->ubr_Frame != 0);
 
     if (urti) {
         if (ioreq->iouh_Dir == UHDIR_IN) {
@@ -1677,6 +1684,8 @@ WORD uhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
             if (urti->urti_OutReqHook)
                 CallHookPkt(urti->urti_OutReqHook, rtn, bufreq);
         }
+        if (bufreq->ubr_Frame)
+            explicit_frame = TRUE;
     } else {
         bufreq->ubr_Buffer = ioreq->iouh_Data;
         bufreq->ubr_Length = ioreq->iouh_Length;
@@ -1686,6 +1695,16 @@ WORD uhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
 
     if (!bufreq->ubr_Length)
         bufreq->ubr_Length = ioreq->iouh_Length;
+
+    if (urti) {
+        if (explicit_frame)
+            rtn->rtn_Flags |= RTISO_FLAG_EXPLICIT_FRAME;
+        else
+            rtn->rtn_Flags &= ~RTISO_FLAG_EXPLICIT_FRAME;
+    }
+
+    if (urti && !(rtn->rtn_Flags & RTISO_FLAG_EXPLICIT_FRAME))
+        bufreq->ubr_Frame = 0;
 
     interval = ioreq->iouh_Interval ? ioreq->iouh_Interval : 1;
     if (!bufreq->ubr_Frame) {
@@ -1831,8 +1850,13 @@ void uhciHandleIsochTDs(struct PCIController *hc)
             }
             CacheClearE(utd, sizeof(*utd), CACRF_InvalidateD);
             ctrl = READMEM32_LE(&utd->utd_CtrlStatus);
-            if(ctrl & UTCF_ACTIVE)
+            if(ctrl & UTCF_ACTIVE) {
+                if (current_frame > ptd->ptd_FrameIdx) {
+                    pciusbUHCIDebug("UHCI", "ISO TD still active ptd=%p frame=%ld current=%ld ctrl=%08lx\n",
+                                    ptd, ptd->ptd_FrameIdx, current_frame, ctrl);
+                }
                 continue;
+            }
 
             if(ctrl & (UTSF_BITSTUFFERR|UTSF_CRCTIMEOUT|UTSF_BABBLE|UTSF_DATABUFFERERR))
                 error = TRUE;

--- a/rom/usb/pciusb/uhci/uhcichip.c
+++ b/rom/usb/pciusb/uhci/uhcichip.c
@@ -1712,11 +1712,11 @@ WORD uhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
     interval = ioreq->iouh_Interval ? ioreq->iouh_Interval : 1;
     if (!bufreq->ubr_Frame) {
         ULONG current_frame;
-        ULONG lead = interval * 4;
+        ULONG lead = interval * 8;
         ULONG next = 0;
 
-        if (lead < 4)
-            lead = 4;
+        if (lead < 8)
+            lead = 8;
 
         uhciUpdateFrameCounter(hc);
         current_frame = hc->hc_FrameCounter;
@@ -1731,11 +1731,11 @@ WORD uhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
                         current_frame, bufreq->ubr_Frame, lead, interval);
     } else {
         ULONG current_frame;
-        ULONG lead = interval * 4;
+        ULONG lead = interval * 8;
         LONG delta;
 
-        if (lead < 4)
-            lead = 4;
+        if (lead < 8)
+            lead = 8;
 
         uhciUpdateFrameCounter(hc);
         current_frame = hc->hc_FrameCounter;
@@ -1750,10 +1750,10 @@ WORD uhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
         }
     }
     if (bufreq->ubr_Frame < hc->hc_FrameCounter) {
-        ULONG lead = interval * 4;
+        ULONG lead = interval * 8;
 
-        if (lead < 4)
-            lead = 4;
+        if (lead < 8)
+            lead = 8;
 
         bufreq->ubr_Frame = hc->hc_FrameCounter + lead;
         pciusbUHCIDebug("UHCI", "ISO schedule resync current=%ld next=%ld lead=%ld interval=%ld\n",
@@ -1806,10 +1806,10 @@ void uhciHandleIsochTDs(struct PCIController *hc)
             ctrl = READMEM32_LE(&utd->utd_CtrlStatus);
             if(ctrl & UTCF_ACTIVE) {
                 interval = rtn->rtn_IOReq.iouh_Interval ? rtn->rtn_IOReq.iouh_Interval : 1;
-                ULONG timeout_window = interval * 2;
+                ULONG timeout_window = interval * 8;
 
-                if (timeout_window < 4)
-                    timeout_window = 4;
+                if (timeout_window < 16)
+                    timeout_window = 16;
 
                 if (current_frame > (ptd->ptd_FrameIdx + timeout_window)) {
                     error = TRUE;

--- a/rom/usb/pciusb/uhci/uhcichip.c
+++ b/rom/usb/pciusb/uhci/uhcichip.c
@@ -1690,8 +1690,11 @@ WORD uhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
     interval = ioreq->iouh_Interval ? ioreq->iouh_Interval : 1;
     if (!bufreq->ubr_Frame) {
         ULONG current_frame;
-        ULONG lead = interval * 2;
+        ULONG lead = interval * 4;
         ULONG next = 0;
+
+        if (lead < 4)
+            lead = 4;
 
         uhciUpdateFrameCounter(hc);
         current_frame = hc->hc_FrameCounter;
@@ -1706,8 +1709,11 @@ WORD uhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
                         current_frame, bufreq->ubr_Frame, lead, interval);
     } else {
         ULONG current_frame;
-        ULONG lead = interval * 2;
+        ULONG lead = interval * 4;
         LONG delta;
+
+        if (lead < 4)
+            lead = 4;
 
         uhciUpdateFrameCounter(hc);
         current_frame = hc->hc_FrameCounter;
@@ -1720,6 +1726,16 @@ WORD uhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
             pciusbUHCIDebug("UHCI", "ISO schedule current=%ld interval=%ld\n",
                             bufreq->ubr_Frame, interval);
         }
+    }
+    if (bufreq->ubr_Frame < hc->hc_FrameCounter) {
+        ULONG lead = interval * 4;
+
+        if (lead < 4)
+            lead = 4;
+
+        bufreq->ubr_Frame = hc->hc_FrameCounter + lead;
+        pciusbUHCIDebug("UHCI", "ISO schedule resync current=%ld next=%ld lead=%ld interval=%ld\n",
+                        hc->hc_FrameCounter, bufreq->ubr_Frame, lead, interval);
     }
     rtn->rtn_NextFrame = bufreq->ubr_Frame + interval;
 
@@ -1735,6 +1751,10 @@ void uhciHandleIsochTDs(struct PCIController *hc)
 {
     struct PCIUnit *unit = hc->hc_Unit;
     struct RTIsoNode *rtn = (struct RTIsoNode *)hc->hc_RTIsoHandlers.mlh_Head;
+    ULONG current_frame;
+
+    uhciUpdateFrameCounter(hc);
+    current_frame = hc->hc_FrameCounter;
 
     while(rtn->rtn_Node.mln_Succ) {
         struct RTIsoNode *next = (struct RTIsoNode *)rtn->rtn_Node.mln_Succ;
@@ -1752,6 +1772,7 @@ void uhciHandleIsochTDs(struct PCIController *hc)
             struct UhciTD *utd;
             ULONG ctrl;
             ULONG actual;
+            ULONG interval;
             BOOL error = FALSE;
             struct IOUsbHWReq *ioreq = pciusbIsoGetIOReq(rtn);
 
@@ -1759,6 +1780,55 @@ void uhciHandleIsochTDs(struct PCIController *hc)
                 continue;
 
             utd = (struct UhciTD *)ptd->ptd_Descriptor;
+            interval = rtn->rtn_IOReq.iouh_Interval ? rtn->rtn_IOReq.iouh_Interval : 1;
+            if (current_frame > (ptd->ptd_FrameIdx + interval)) {
+                error = TRUE;
+                ioreq->iouh_Req.io_Error = UHIOERR_TIMEOUT;
+                ioreq->iouh_Actual = 0;
+                ptd->ptd_BufferReq.ubr_Length = 0;
+                ptd->ptd_BufferReq.ubr_Frame = ptd->ptd_FrameIdx;
+                uhciUnlinkIsoPTD(hc, ptd);
+                if (urti) {
+                    if (ioreq->iouh_Dir == UHDIR_IN) {
+                        if (urti->urti_InDoneHook)
+                            CallHookPkt(urti->urti_InDoneHook, rtn, &ptd->ptd_BufferReq);
+                    } else {
+                        if (urti->urti_OutDoneHook)
+                            CallHookPkt(urti->urti_OutDoneHook, rtn, &ptd->ptd_BufferReq);
+                    }
+                }
+                ptd->ptd_Flags &= ~(PTDF_ACTIVE|PTDF_BUFFER_VALID);
+                if (utd) {
+                    uhciFreeTD(hc, utd);
+                    ptd->ptd_Descriptor = NULL;
+                }
+                if (rtn->rtn_StdReq) {
+                    UWORD devadrep = (ioreq->iouh_DevAddr << 5) + ioreq->iouh_Endpoint +
+                                     ((ioreq->iouh_Dir == UHDIR_IN) ? 0x10 : 0);
+                    Remove((struct Node *)&rtn->rtn_Node);
+                    unit->hu_DevBusyReq[devadrep] = NULL;
+                    ReplyMsg(&ioreq->iouh_Req.io_Message);
+                    uhciFreeIsochIO(hc, rtn);
+                    pciusbFreeStdIsoNode(hc, rtn);
+                } else if (urti) {
+                    UWORD pending = 0;
+                    UWORD target = (rtn->rtn_PTDCount > 1) ? 2 : 1;
+
+                    for (UWORD scan = 0; scan < rtn->rtn_PTDCount; scan++) {
+                        struct PTDNode *ptdscan = rtn->rtn_PTDs[scan];
+                        if (ptdscan && (ptdscan->ptd_Flags & (PTDF_ACTIVE | PTDF_BUFFER_VALID)))
+                            pending++;
+                    }
+
+                    while (pending < target) {
+                        if (uhciQueueIsochIO(hc, rtn) != RC_OK)
+                            break;
+                        uhciStartIsochIO(hc, rtn);
+                        pending++;
+                    }
+                }
+                continue;
+            }
             CacheClearE(utd, sizeof(*utd), CACRF_InvalidateD);
             ctrl = READMEM32_LE(&utd->utd_CtrlStatus);
             if(ctrl & UTCF_ACTIVE)
@@ -1908,6 +1978,8 @@ void uhciStartIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
         ptd->ptd_Flags |= PTDF_ACTIVE;
         ptd->ptd_NextPTD = NULL;
 
+        pciusbUHCIDebug("UHCI", "ISO TD ptd=%p utd=%p frame=%ld slot=%ld len=%ld\n",
+                        ptd, utd, ptd->ptd_FrameIdx, slot, len);
         uhciInsertIsoPTD(hc, ptd, slot);
     }
 }

--- a/rom/usb/pciusb/uhci/uhcichip.c
+++ b/rom/usb/pciusb/uhci/uhcichip.c
@@ -1803,12 +1803,17 @@ void uhciHandleIsochTDs(struct PCIController *hc)
 
             utd = (struct UhciTD *)ptd->ptd_Descriptor;
             interval = rtn->rtn_IOReq.iouh_Interval ? rtn->rtn_IOReq.iouh_Interval : 1;
-            if (current_frame > (ptd->ptd_FrameIdx + interval)) {
+            ULONG timeout_window = interval * 2;
+            if (timeout_window < 4)
+                timeout_window = 4;
+            if (current_frame > (ptd->ptd_FrameIdx + timeout_window)) {
                 error = TRUE;
                 ioreq->iouh_Req.io_Error = UHIOERR_TIMEOUT;
                 ioreq->iouh_Actual = 0;
                 ptd->ptd_BufferReq.ubr_Length = 0;
                 ptd->ptd_BufferReq.ubr_Frame = ptd->ptd_FrameIdx;
+                pciusbUHCIDebug("UHCI", "ISO TD timeout ptd=%p frame=%ld current=%ld window=%ld\n",
+                                ptd, ptd->ptd_FrameIdx, current_frame, timeout_window);
                 uhciUnlinkIsoPTD(hc, ptd);
                 if (urti) {
                     if (ioreq->iouh_Dir == UHDIR_IN) {

--- a/rom/usb/pciusb/uhci/uhcichip.c
+++ b/rom/usb/pciusb/uhci/uhcichip.c
@@ -1674,7 +1674,10 @@ WORD uhciQueueIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
 
     struct IOUsbHWBufferReq *bufreq = &ptd->ptd_BufferReq;
     *bufreq = rtn->rtn_BufferReq;
-    explicit_frame = (bufreq->ubr_Frame != 0);
+    explicit_frame = (rtn->rtn_Flags & RTISO_FLAG_EXPLICIT_FRAME) != 0;
+
+    if (urti && !explicit_frame)
+        bufreq->ubr_Frame = 0;
 
     if (urti) {
         if (ioreq->iouh_Dir == UHDIR_IN) {

--- a/rom/usb/pciusb/uhci/uhcichip.c
+++ b/rom/usb/pciusb/uhci/uhcichip.c
@@ -1802,63 +1802,65 @@ void uhciHandleIsochTDs(struct PCIController *hc)
                 continue;
 
             utd = (struct UhciTD *)ptd->ptd_Descriptor;
-            interval = rtn->rtn_IOReq.iouh_Interval ? rtn->rtn_IOReq.iouh_Interval : 1;
-            ULONG timeout_window = interval * 2;
-            if (timeout_window < 4)
-                timeout_window = 4;
-            if (current_frame > (ptd->ptd_FrameIdx + timeout_window)) {
-                error = TRUE;
-                ioreq->iouh_Req.io_Error = UHIOERR_TIMEOUT;
-                ioreq->iouh_Actual = 0;
-                ptd->ptd_BufferReq.ubr_Length = 0;
-                ptd->ptd_BufferReq.ubr_Frame = ptd->ptd_FrameIdx;
-                pciusbUHCIDebug("UHCI", "ISO TD timeout ptd=%p frame=%ld current=%ld window=%ld\n",
-                                ptd, ptd->ptd_FrameIdx, current_frame, timeout_window);
-                uhciUnlinkIsoPTD(hc, ptd);
-                if (urti) {
-                    if (ioreq->iouh_Dir == UHDIR_IN) {
-                        if (urti->urti_InDoneHook)
-                            CallHookPkt(urti->urti_InDoneHook, rtn, &ptd->ptd_BufferReq);
-                    } else {
-                        if (urti->urti_OutDoneHook)
-                            CallHookPkt(urti->urti_OutDoneHook, rtn, &ptd->ptd_BufferReq);
-                    }
-                }
-                ptd->ptd_Flags &= ~(PTDF_ACTIVE|PTDF_BUFFER_VALID);
-                if (utd) {
-                    uhciFreeTD(hc, utd);
-                    ptd->ptd_Descriptor = NULL;
-                }
-                if (rtn->rtn_StdReq) {
-                    UWORD devadrep = (ioreq->iouh_DevAddr << 5) + ioreq->iouh_Endpoint +
-                                     ((ioreq->iouh_Dir == UHDIR_IN) ? 0x10 : 0);
-                    Remove((struct Node *)&rtn->rtn_Node);
-                    unit->hu_DevBusyReq[devadrep] = NULL;
-                    ReplyMsg(&ioreq->iouh_Req.io_Message);
-                    uhciFreeIsochIO(hc, rtn);
-                    pciusbFreeStdIsoNode(hc, rtn);
-                } else if (urti) {
-                    UWORD pending = 0;
-                    UWORD target = (rtn->rtn_PTDCount > 1) ? 2 : 1;
-
-                    for (UWORD scan = 0; scan < rtn->rtn_PTDCount; scan++) {
-                        struct PTDNode *ptdscan = rtn->rtn_PTDs[scan];
-                        if (ptdscan && (ptdscan->ptd_Flags & (PTDF_ACTIVE | PTDF_BUFFER_VALID)))
-                            pending++;
-                    }
-
-                    while (pending < target) {
-                        if (uhciQueueIsochIO(hc, rtn) != RC_OK)
-                            break;
-                        uhciStartIsochIO(hc, rtn);
-                        pending++;
-                    }
-                }
-                continue;
-            }
             CacheClearE(utd, sizeof(*utd), CACRF_InvalidateD);
             ctrl = READMEM32_LE(&utd->utd_CtrlStatus);
             if(ctrl & UTCF_ACTIVE) {
+                interval = rtn->rtn_IOReq.iouh_Interval ? rtn->rtn_IOReq.iouh_Interval : 1;
+                ULONG timeout_window = interval * 2;
+
+                if (timeout_window < 4)
+                    timeout_window = 4;
+
+                if (current_frame > (ptd->ptd_FrameIdx + timeout_window)) {
+                    error = TRUE;
+                    ioreq->iouh_Req.io_Error = UHIOERR_TIMEOUT;
+                    ioreq->iouh_Actual = 0;
+                    ptd->ptd_BufferReq.ubr_Length = 0;
+                    ptd->ptd_BufferReq.ubr_Frame = ptd->ptd_FrameIdx;
+                    pciusbUHCIDebug("UHCI", "ISO TD timeout ptd=%p frame=%ld current=%ld window=%ld\n",
+                                    ptd, ptd->ptd_FrameIdx, current_frame, timeout_window);
+                    uhciUnlinkIsoPTD(hc, ptd);
+                    if (urti) {
+                        if (ioreq->iouh_Dir == UHDIR_IN) {
+                            if (urti->urti_InDoneHook)
+                                CallHookPkt(urti->urti_InDoneHook, rtn, &ptd->ptd_BufferReq);
+                        } else {
+                            if (urti->urti_OutDoneHook)
+                                CallHookPkt(urti->urti_OutDoneHook, rtn, &ptd->ptd_BufferReq);
+                        }
+                    }
+                    ptd->ptd_Flags &= ~(PTDF_ACTIVE|PTDF_BUFFER_VALID);
+                    if (utd) {
+                        uhciFreeTD(hc, utd);
+                        ptd->ptd_Descriptor = NULL;
+                    }
+                    if (rtn->rtn_StdReq) {
+                        UWORD devadrep = (ioreq->iouh_DevAddr << 5) + ioreq->iouh_Endpoint +
+                                         ((ioreq->iouh_Dir == UHDIR_IN) ? 0x10 : 0);
+                        Remove((struct Node *)&rtn->rtn_Node);
+                        unit->hu_DevBusyReq[devadrep] = NULL;
+                        ReplyMsg(&ioreq->iouh_Req.io_Message);
+                        uhciFreeIsochIO(hc, rtn);
+                        pciusbFreeStdIsoNode(hc, rtn);
+                    } else if (urti) {
+                        UWORD pending = 0;
+                        UWORD target = (rtn->rtn_PTDCount > 1) ? 2 : 1;
+
+                        for (UWORD scan = 0; scan < rtn->rtn_PTDCount; scan++) {
+                            struct PTDNode *ptdscan = rtn->rtn_PTDs[scan];
+                            if (ptdscan && (ptdscan->ptd_Flags & (PTDF_ACTIVE | PTDF_BUFFER_VALID)))
+                                pending++;
+                        }
+
+                        while (pending < target) {
+                            if (uhciQueueIsochIO(hc, rtn) != RC_OK)
+                                break;
+                            uhciStartIsochIO(hc, rtn);
+                            pending++;
+                        }
+                    }
+                    continue;
+                }
                 if (current_frame > ptd->ptd_FrameIdx) {
                     pciusbUHCIDebug("UHCI", "ISO TD still active ptd=%p frame=%ld current=%ld ctrl=%08lx\n",
                                     ptd, ptd->ptd_FrameIdx, current_frame, ctrl);

--- a/rom/usb/pciusb/uhwcmd.c
+++ b/rom/usb/pciusb/uhwcmd.c
@@ -1830,20 +1830,25 @@ WORD cmdStartRTIso(struct IOUsbHWReq *ioreq,
 
     UWORD prefill = (rtn->rtn_PTDCount > 1) ? 2 : 1;
     for (UWORD cnt = 0; cnt < prefill; cnt++) {
+        WORD queueresult = RC_OK;
         switch(hc->hc_HCIType) {
         case HCITYPE_XHCI:
-            xhciQueueIsochIO(hc, rtn);
+            queueresult = xhciQueueIsochIO(hc, rtn);
             break;
         case HCITYPE_EHCI:
-            ehciQueueIsochIO(hc, rtn);
+            queueresult = ehciQueueIsochIO(hc, rtn);
             break;
         case HCITYPE_UHCI:
-            uhciQueueIsochIO(hc, rtn);
+            queueresult = uhciQueueIsochIO(hc, rtn);
             break;
         default:
-            ohciQueueIsochIO(hc, rtn);
+            queueresult = ohciQueueIsochIO(hc, rtn);
             break;
         };
+        if (queueresult != RC_OK) {
+            Enable();
+            return queueresult;
+        }
     }
 
     switch(hc->hc_HCIType) {


### PR DESCRIPTION
### Motivation
- Ensure RTIso startup fails cleanly when underlying controller queueing cannot allocate resources. 
- Align UHCI RTIso completion hook behavior with other controller implementations to avoid duplicate/inconsistent callbacks. 
- Prevent scheduling isochronous frames far in the future and keep a small steady in-flight depth to reduce underrun risk. 

### Description
- In `cmdStartRTIso` capture return values from `xhci/ehci/uhci/ohciQueueIsochIO` into `queueresult` and return early (re-enabling interrupts) when a queue call fails. 
- In `uhciQueueIsochIO` clamp `ubr_Frame` when it is already set by comparing to the current frame via `uhciUpdateFrameCounter` and adjust to `current + lead` when out of range. 
- In `uhciHandleIsochTDs` stop invoking the `urti_InReqHook` on completion and instead compute current `pending` PTDs and loop to queue/start additional UHCI isoch IOs until a `target` in-flight depth (1 or 2) is reached or queueing fails. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bfaa35a748329bc4e08008d51d3fe)