### PR TITLE
Move BOS capability tracking to devices

### DIFF
--- a/rom/usb/poseidon/poseidon.library.c
+++ b/rom/usb/poseidon/poseidon.library.c
@@ -2821,39 +2821,39 @@ static void DumpPipe(struct PsdPipe *pp)
  * Map BOS-derived capabilities into poseidons hardware structure.
   */
 static void
-pUpdateHardwareFromBos(struct PsdHardware *phw, const struct PsdBosCaps *caps)
+pUpdateHardwareFromBos(struct PsdDevice *pd, const struct PsdBosCaps *caps)
 {
-    if (!phw || !caps || !caps->hasBos)
+    if (!pd || !caps || !caps->hasBos)
         return;
 
     /* USB 2.0 LPM (L1) */
     if (caps->hasUsb20Ext) {
-        phw->phw_Usb20LpmCapable = caps->usb20LpmCapable;
+        pd->pd_Usb20LpmCapable = caps->usb20LpmCapable;
     }
 
     /* SuperSpeed device capability */
     if (caps->hasSSCap) {
-        phw->phw_Usb30LtmCapable   = (caps->ssBmAttributes & 0x02) ? TRUE : FALSE;
-        phw->phw_SupportedSpeeds  |= caps->ssSpeedsSupported;
-        phw->phw_Usb30U1ExitLat    = caps->ssU1DevExitLat;
-        phw->phw_Usb30U2ExitLat    = caps->ssU2DevExitLat;
+        pd->pd_Usb30LtmCapable   = (caps->ssBmAttributes & 0x02) ? TRUE : FALSE;
+        pd->pd_SupportedSpeeds  |= caps->ssSpeedsSupported;
+        pd->pd_Usb30U1ExitLat    = caps->ssU1DevExitLat;
+        pd->pd_Usb30U2ExitLat    = caps->ssU2DevExitLat;
 
         /* Choose the highest supported speed */
         if (caps->ssSpeedsSupported & (1U << 3)) {          /* SuperSpeed */
-            phw->phw_MaxUsbSpeed = 4;
+            pd->pd_MaxUsbSpeed = 4;
         } else if (caps->ssSpeedsSupported & (1U << 2)) {   /* High-speed */
-            phw->phw_MaxUsbSpeed = 3;
+            pd->pd_MaxUsbSpeed = 3;
         } else if (caps->ssSpeedsSupported & (1U << 1)) {   /* Full-speed */
-            phw->phw_MaxUsbSpeed = 2;
+            pd->pd_MaxUsbSpeed = 2;
         } else if (caps->ssSpeedsSupported & (1U << 0)) {   /* Low-speed */
-            phw->phw_MaxUsbSpeed = 1;
+            pd->pd_MaxUsbSpeed = 1;
         }
     }
 
     /* Container ID */
     if (caps->hasContainerId) {
-        phw->phw_HasContainerId = TRUE;
-        CopyMem(caps->containerId, phw->phw_ContainerId, 16);
+        pd->pd_HasContainerId = TRUE;
+        CopyMem(caps->containerId, pd->pd_ContainerId, 16);
     }
 }
 
@@ -3044,7 +3044,7 @@ pBuildDefaultPowerPolicy(struct PsdHardware *phw, struct PsdDevice *pd,
     policy |= USBPWR_POLICY_BALANCED;
 
     /* USB 2.0 LPM (L1) */
-    if (phw->phw_Usb20LpmCapable &&
+    if (pd->pd_Usb20LpmCapable &&
             pd->pd_USBVers >= 0x0201) {
         policy |= USBPWR_ALLOW_L1;
     }
@@ -3052,12 +3052,12 @@ pBuildDefaultPowerPolicy(struct PsdHardware *phw, struct PsdDevice *pd,
     /* USB 3.x link states */
     if (pd->pd_Flags & PDFF_SUPERSPEED) {
         /* U1 is usually safe for most endpoints if U1 exit latency is low */
-        if (phw->phw_Usb30U1ExitLat != 0) {
+        if (pd->pd_Usb30U1ExitLat != 0) {
             policy |= USBPWR_ALLOW_U1;
         }
 
         /* U2 is deeper; be more conservative for time-sensitive endpoints */
-        if (phw->phw_Usb30U2ExitLat != 0 &&
+        if (pd->pd_Usb30U2ExitLat != 0 &&
                 pep && pep->pep_TransType != USEAF_ISOCHRONOUS) {
             policy |= USBPWR_ALLOW_U2;
         }
@@ -3328,8 +3328,8 @@ AROS_LH1(struct PsdDevice *, psdEnumerateDevice,
     */
     if (pd->pd_USBVers > 0x0200) {
         struct PsdBosCaps boscaps;
-        if (pFetchBosCaps(pp, &boscaps) && pd->pd_Hardware) {
-            pUpdateHardwareFromBos(pd->pd_Hardware, &boscaps);
+        if (pFetchBosCaps(pp, &boscaps)) {
+            pUpdateHardwareFromBos(pd, &boscaps);
         }
     }
 
@@ -9427,4 +9427,3 @@ static const ULONG *PsdPTArray[] = {
     PsdRTIsoHandlerPT
 };
 /* \\\ */
-

--- a/rom/usb/poseidon/poseidon.library.c
+++ b/rom/usb/poseidon/poseidon.library.c
@@ -2821,7 +2821,7 @@ static void DumpPipe(struct PsdPipe *pp)
  * Map BOS-derived capabilities into poseidons hardware structure.
   */
 static void
-pUpdateDeviceFromBos(struct PsdDevice *pd, const struct PsdBosCaps *caps)
+pApplyDeviceBosCapabilities(struct PsdDevice *pd, const struct PsdBosCaps *caps)
 {
     if (!pd || !caps || !caps->hasBos)
         return;
@@ -3329,7 +3329,7 @@ AROS_LH1(struct PsdDevice *, psdEnumerateDevice,
     if (pd->pd_USBVers > 0x0200) {
         struct PsdBosCaps boscaps;
         if (pFetchBosCaps(pp, &boscaps)) {
-            pUpdateDeviceFromBos(pd, &boscaps);
+            pApplyDeviceBosCapabilities(pd, &boscaps);
         }
     }
 

--- a/rom/usb/poseidon/poseidon.library.c
+++ b/rom/usb/poseidon/poseidon.library.c
@@ -2821,7 +2821,7 @@ static void DumpPipe(struct PsdPipe *pp)
  * Map BOS-derived capabilities into poseidons hardware structure.
   */
 static void
-pUpdateHardwareFromBos(struct PsdDevice *pd, const struct PsdBosCaps *caps)
+pUpdateDeviceFromBos(struct PsdDevice *pd, const struct PsdBosCaps *caps)
 {
     if (!pd || !caps || !caps->hasBos)
         return;
@@ -3329,7 +3329,7 @@ AROS_LH1(struct PsdDevice *, psdEnumerateDevice,
     if (pd->pd_USBVers > 0x0200) {
         struct PsdBosCaps boscaps;
         if (pFetchBosCaps(pp, &boscaps)) {
-            pUpdateHardwareFromBos(pd, &boscaps);
+            pUpdateDeviceFromBos(pd, &boscaps);
         }
     }
 

--- a/rom/usb/poseidon/poseidon_intern.h
+++ b/rom/usb/poseidon/poseidon_intern.h
@@ -359,19 +359,6 @@ struct PsdHardware
     struct MsgPort      phw_TaskMsgPort;        /* Quick task message port */
     volatile ULONG      phw_MsgCount;           /* Number of Messages pending */
 
-    /* BOS-derived capability summary */
-    BOOL                phw_Usb20LpmCapable;        /* Device supports USB 2.0 LPM (L1) */
-    BOOL                phw_Usb30LtmCapable;        /* Device supports USB 3.0 Latency Tolerance Messaging (LTM) */
-
-    UWORD               phw_SupportedSpeeds;        /* Bitmask of speeds (USB 3.0 wSpeedSupported) */
-    UBYTE               phw_Usb30U1ExitLat;         /* Exit latency to U0 from U1 */
-    UWORD               phw_Usb30U2ExitLat;         /* Exit latency to U0 from U2 */
-
-    UBYTE               phw_MaxUsbSpeed;            /* store our “chosen” max speed */
-                                                    /* e.g., 1=LS, 2=FS, 3=HS, 4=SS */
-
-    BOOL                phw_HasContainerId;
-    UBYTE               phw_ContainerId[16];
 };
 
 /* Flags for pd_Flags */
@@ -433,6 +420,17 @@ struct PsdDevice
     struct PsdPoPoCfg   pd_PoPoCfg;       /* Inhibit PopUp and Class scan Config */
     struct List         pd_Descriptors;   /* Descriptors collected */
     struct List         pd_RTIsoHandlers; /* List of RTIsoHandlers */
+
+    /* BOS-derived capability summary */
+    BOOL                pd_Usb20LpmCapable;        /* Device supports USB 2.0 LPM (L1) */
+    BOOL                pd_Usb30LtmCapable;        /* Device supports USB 3.0 Latency Tolerance Messaging (LTM) */
+    UWORD               pd_SupportedSpeeds;        /* Bitmask of speeds (USB 3.0 wSpeedSupported) */
+    UBYTE               pd_Usb30U1ExitLat;         /* Exit latency to U0 from U1 */
+    UWORD               pd_Usb30U2ExitLat;         /* Exit latency to U0 from U2 */
+    UBYTE               pd_MaxUsbSpeed;            /* store our chosen max speed */
+                                                   /* e.g., 1=LS, 2=FS, 3=HS, 4=SS */
+    BOOL                pd_HasContainerId;
+    UBYTE               pd_ContainerId[16];
 };
 
 struct PsdDescriptor
@@ -488,7 +486,7 @@ struct PsdEndpoint
     UWORD               pep_Direction;    /* Direction (0=OUT, 1=IN) */
     UWORD               pep_TransType;    /* TransferType, see USEA-Flags */
     UWORD               pep_MaxPktSize;   /* Maximum packet size for EP */
-    UWORD               pep_NumTransMuFr; /* Number of transactions per µFrame */
+    UWORD               pep_NumTransMuFr; /* Number of transactions per ÂµFrame */
     UWORD               pep_Interval;     /* Interval for polling in ms */
     UWORD               pep_SyncType;     /* Iso Synchronization Type */
     UWORD               pep_UsageType;    /* Iso Usage Type */


### PR DESCRIPTION
### Motivation

- BOS-derived capability fields were stored on the `PsdHardware` structure but represent per-device capabilities and must be tracked per device.
- Default power-policy decisions and endpoint policies need to read the actual device's BOS data so policies reflect each device's capabilities.

### Description

- Removed the BOS fields from `struct PsdHardware` and added equivalent `pd_` fields to `struct PsdDevice` (e.g. `pd_Usb20LpmCapable`, `pd_Usb30LtmCapable`, `pd_SupportedSpeeds`, `pd_Usb30U1ExitLat`, `pd_Usb30U2ExitLat`, `pd_MaxUsbSpeed`, `pd_HasContainerId`, `pd_ContainerId`).
- Changed `pUpdateHardwareFromBos` to accept a `struct PsdDevice *pd` and populate the new `pd_` fields instead of writing `phw_` fields.
- Updated `pBuildDefaultPowerPolicy` to consult device fields (e.g. `pd->pd_Usb20LpmCapable`, `pd->pd_Usb30U1ExitLat`, `pd->pd_Usb30U2ExitLat`) when deciding `USBPWR_ALLOW_*` flags.
- Adjusted the BOS parsing/call site in `psdEnumerateDevice` to call `pUpdateHardwareFromBos(pd, &boscaps)` after fetching BOS data.

### Testing

- No automated tests were executed for this change.
- The change was built into the repository and committed (local commit showing two files modified).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cec0a0fd0832991048f6eebbd4d8e)