### PR TITLE
Fix SuperSpeed endpoint companion handling for non-iso/interrupt endpoints

### DIFF
--- a/rom/usb/poseidon/poseidon.library.c
+++ b/rom/usb/poseidon/poseidon.library.c
@@ -4259,12 +4259,17 @@ AROS_LH3(struct PsdPipe *, psdAllocPipe,
                 else
                     pp->pp_IOReq.iouh_SS_Mult = 0;
 
-                /* wBytesPerInterval - spec is 16 bits; field is UWORD */
-                if (pep->pep_BytesPerInterval > 0xFFFFUL)
-                    pp->pp_IOReq.iouh_SS_BytesPerInterval = 0xFFFF;
-                else
-                    pp->pp_IOReq.iouh_SS_BytesPerInterval =
-                        (UWORD)pep->pep_BytesPerInterval;
+                /* wBytesPerInterval - only valid for isoch/interrupt endpoints */
+                if (pep->pep_TransType == USEAF_ISOCHRONOUS ||
+                    pep->pep_TransType == USEAF_INTERRUPT) {
+                    if (pep->pep_BytesPerInterval > 0xFFFFUL)
+                        pp->pp_IOReq.iouh_SS_BytesPerInterval = 0xFFFF;
+                    else
+                        pp->pp_IOReq.iouh_SS_BytesPerInterval =
+                            (UWORD)pep->pep_BytesPerInterval;
+                } else {
+                    pp->pp_IOReq.iouh_SS_BytesPerInterval = 0;
+                }
 
                 if (pep->pep_TransType == USEAF_BULK) {
                     UWORD attr = pep->pep_CompAttributes;
@@ -8118,7 +8123,7 @@ BOOL pGetDevConfig(struct PsdPipe *pp)
                                     pep->pep_Interval = usep->bInterval;
                                     pep->pep_MaxBurst = 1;
                                     pep->pep_CompAttributes = 0;
-                                    pep->pep_BytesPerInterval = pep->pep_MaxPktSize;
+                                    pep->pep_BytesPerInterval = 0;
                                     if(pd->pd_Flags & PDFF_SUPERSPEED) {
                                         switch(pep->pep_TransType) {
                                         case USEAF_CONTROL:
@@ -8262,14 +8267,25 @@ BOOL pGetDevConfig(struct PsdPipe *pp)
                         case UDT_SUPERSPEED_EP_COMP: {
                             struct UsbSSEndpointCompDesc *comp = (struct UsbSSEndpointCompDesc *) dbuf;
                             if(pep) {
+                                if (dlen < sizeof(struct UsbSSEndpointCompDesc)) {
+                                    psdAddErrorMsg0(RETURN_WARN, (STRPTR) GM_UNIQUENAME(libname),
+                                                    "Superspeed companion descriptor too small!");
+                                    break;
+                                }
                                 pep->pep_MaxBurst = comp->bMaxBurst + 1;
                                 pep->pep_CompAttributes = comp->bmAttributes;
-                                pep->pep_BytesPerInterval = AROS_LE2WORD(comp->wBytesPerInterval);
+                                if (pep->pep_TransType == USEAF_INTERRUPT ||
+                                    pep->pep_TransType == USEAF_ISOCHRONOUS) {
+                                    pep->pep_BytesPerInterval = AROS_LE2WORD(comp->wBytesPerInterval);
+                                } else {
+                                    pep->pep_BytesPerInterval = 0;
+                                }
                                 if((pd->pd_Flags & PDFF_SUPERSPEED) && (pep->pep_TransType == USEAF_ISOCHRONOUS)) {
                                     pep->pep_NumTransMuFr = (comp->bmAttributes & 0x03) + 1;
                                 }
                             } else {
-                                psdAddErrorMsg0(RETURN_WARN, (STRPTR) GM_UNIQUENAME(libname), "Superspeed companion without prior endpoint descriptor!");
+                                psdAddErrorMsg0(RETURN_WARN, (STRPTR) GM_UNIQUENAME(libname),
+                                                "Superspeed companion without prior endpoint descriptor!");
                             }
                             break;
                         }


### PR DESCRIPTION
### Motivation
- Avoid treating `wBytesPerInterval` as valid for Bulk/Control endpoints and prevent incorrect bytes-per-interval values being applied from endpoint max packet size.
- Ensure SuperSpeed endpoint companion descriptors are validated for length before parsing to avoid reading past the descriptor buffer.
- Ensure the V3 IOReq `iouh_SS_BytesPerInterval` field is zeroed when the endpoint transfer type does not use it.

### Description
- Changed initialization of `pep->pep_BytesPerInterval` to `0` instead of defaulting to `pep->pep_MaxPktSize` in `rom/usb/poseidon/poseidon.library.c` when allocating endpoints.
- Added a size check for `UDT_SUPERSPEED_EP_COMP` companion descriptors and only assign `pep->pep_BytesPerInterval` for `USEAF_ISOCHRONOUS` or `USEAF_INTERRUPT` endpoints, otherwise set it to `0`.
- Updated mapping into the IO request so `pp->pp_IOReq.iouh_SS_BytesPerInterval` is only populated for isochronous/interrupt endpoints and cleared to `0` for other transfer types.
- File modified: `rom/usb/poseidon/poseidon.library.c` to implement the above changes.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cf6131e2c83299aa13bd64a0ec537)