### PR TITLE
Hoist pcixhci runtime string literals to file-scope globals

### DIFF
--- a/rom/usb/pcixhci/pcixhci_arospci.c
+++ b/rom/usb/pcixhci/pcixhci_arospci.c
@@ -39,6 +39,14 @@
 #define LogResBase (base->hd_LogResBase)
 #endif
 
+static const char strPcixhciDevicePrefix[] = "pcixhci.device/";
+static const char strPcixhciDeviceFormat[] = "pcixhci.device/%u";
+static const char strProductPciPrefix[] = "PCI ";
+static const char strProductXhci[] = "xHCI ";
+static const char strProductUsb[] = " USB ";
+static const char strProductHostController[] = " Host Controller";
+static const char strEmpty[] = "";
+
 extern int XHCIControllerOOPStartup(struct PCIDevice *hd);
 
 AROS_UFH3(void, pciEnumerator,
@@ -217,10 +225,11 @@ BOOL pciInit(struct PCIDevice *hd)
                         {aHidd_DriverData,          (IPTR)hc        },
                         {TAG_DONE,                  0               }
                     };
-                    int name_len = sizeof("pcixhci.device/") - 1 + 10 + 1;
+                    int name_len = sizeof(strPcixhciDevicePrefix) - 1 + 10 + 1;
                     hc->hc_Node.ln_Name = AllocVec(name_len, MEMF_CLEAR);
                     hc->hc_Node.ln_Pri = HCITYPE_XHCI;
-                    sprintf(hc->hc_Node.ln_Name, "pcixhci.device/%u", (hu->hu_UnitNo & ~PCIUSBUNIT_MASK));
+                    sprintf(hc->hc_Node.ln_Name, strPcixhciDeviceFormat,
+                            (hu->hu_UnitNo & ~PCIUSBUNIT_MASK));
                     usbc_tags[0].ti_Data = (IPTR)hc->hc_Node.ln_Name;
                     pciusbWarn("PCI", "Instantiating xHCI controller class for '%s'\n", hc->hc_Node.ln_Name);
                     HW_AddDriver(root, hd->hd_USBXHCIControllerClass, usbc_tags);
@@ -255,7 +264,7 @@ static void pciusbUpdateVersion(UBYTE major, UBYTE minor, UBYTE *bestMajor, UBYT
 
 static void pciusbAppendVersion(STRPTR dest, UBYTE major, UBYTE minor)
 {
-    STRPTR vers = pciStrcat(dest, "");
+    STRPTR vers = pciStrcat(dest, strEmpty);
     vers[0] = (char)('0' + (major % 10));
     vers[1] = '.';
     vers[2] = (char)('0' + (minor % 10));
@@ -345,8 +354,8 @@ BOOL pciAllocUnit(struct PCIUnit *hu)
     // create product name of device
     prodname = hu->hu_ProductName;
     *prodname = 0;
-    pciStrcat(prodname, "PCI ");
-    pciStrcat(prodname, "xHCI ");
+    pciStrcat(prodname, strProductPciPrefix);
+    pciStrcat(prodname, strProductXhci);
     pciusbAppendVersion(prodname, hciMajor, hciMinor);
 
     // put em online
@@ -355,9 +364,9 @@ BOOL pciAllocUnit(struct PCIUnit *hu)
     }
 
     // now add the USB version information to the product name.
-    pciStrcat(prodname, " USB ");
+    pciStrcat(prodname, strProductUsb);
     pciusbAppendVersion(prodname, usbMajor, usbMinor);
-    pciStrcat(prodname, " Host Controller");
+    pciStrcat(prodname, strProductHostController);
     pciusbDebug("PCI", "Unit allocated!\n");
 
     return TRUE;

--- a/rom/usb/pcixhci/pcixhci_dev.c
+++ b/rom/usb/pcixhci/pcixhci_dev.c
@@ -17,6 +17,8 @@
 #define NewList NEWLIST
 
 const char devname[]     = MOD_NAME_STRING;
+static const char strOopLibraryName[] = "oop.library";
+static const char strUtilityLibraryName[] = "utility.library";
 
 #if defined(__OOP_NOATTRBASES__)
 /* Keep order the same as order of IDs in struct e1000Base! */
@@ -55,7 +57,7 @@ static int devInit(LIBBASETYPEPTR base)
             base, SysBase);
 
 #if defined(__OOP_NOLIBBASE__)
-    if ((base->hd_OOPBase = OpenLibrary("oop.library",0)) == NULL) {
+    if ((base->hd_OOPBase = OpenLibrary(strOopLibraryName, 0)) == NULL) {
         KPRINTF(10, "devInit: Failed to open oop.library!\n");
         return FALSE;
     }
@@ -82,7 +84,7 @@ static int devInit(LIBBASETYPEPTR base)
     }
 #endif
 
-    base->hd_UtilityBase = (struct UtilityBase *) OpenLibrary("utility.library", 39);
+    base->hd_UtilityBase = (struct UtilityBase *) OpenLibrary(strUtilityLibraryName, 39);
 
 #define	UtilityBase	base->hd_UtilityBase
 

--- a/rom/usb/pcixhci/uhwcmd.c
+++ b/rom/usb/pcixhci/uhwcmd.c
@@ -123,7 +123,14 @@ const struct  UsbSSHubDesc    RHHubSSDesc = {
 
 static const char strStandardConfig[] = "Standard Config";
 static const char strHubInterface[] = "Hub interface";
-const CONST_STRPTR RHStrings[] = { "The AROS Dev Team", "PCI Superspeed Root Hub Unit x", strStandardConfig, strHubInterface };
+static const char strTimerDeviceName[] = "timer.device";
+static const char strTimerHardwareName[] = "PCI hardware";
+static const char strNakTimeoutName[] = "PCIUSB NakTimeout";
+static const char strArosDevTeam[] = "The AROS Dev Team";
+static const char strRootHubProduct[] = "PCI Superspeed Root Hub Unit x";
+static const char strXhciDescription[] = "xHCI host controller driver for PCI cards";
+static const char strXhciCopyright[] = "\xA9""2023-2026 The AROS Dev Team";
+const CONST_STRPTR RHStrings[] = { strArosDevTeam, strRootHubProduct, strStandardConfig, strHubInterface };
 
 /* /// "SureCause()" */
 void SureCause(struct PCIDevice *base, struct Interrupt *interrupt)
@@ -158,8 +165,8 @@ BOOL uhwOpenTimer(struct PCIUnit *unit, struct PCIDevice *base)
 {
     if((unit->hu_MsgPort = CreateMsgPort())) {
         if((unit->hu_TimerReq = (struct timerequest *) CreateIORequest(unit->hu_MsgPort, sizeof(struct timerequest)))) {
-            if(!OpenDevice("timer.device", UNIT_MICROHZ, (struct IORequest *) unit->hu_TimerReq, 0)) {
-                unit->hu_TimerReq->tr_node.io_Message.mn_Node.ln_Name = "PCI hardware";
+            if(!OpenDevice(strTimerDeviceName, UNIT_MICROHZ, (struct IORequest *) unit->hu_TimerReq, 0)) {
+                unit->hu_TimerReq->tr_node.io_Message.mn_Node.ln_Name = strTimerHardwareName;
                 unit->hu_TimerReq->tr_node.io_Command = TR_ADDREQUEST;
                 KPRINTF(1, "opened timer device\n");
                 return(TRUE);
@@ -247,7 +254,7 @@ struct Unit * Open_Unit(struct IOUsbHWReq *ioreq,
             unit->hu_UnitNo |= PCIUSBUNIT_MASK;                                                 // Mark the unit as allocated/opened
 
             unit->hu_NakTimeoutInt.is_Node.ln_Type = NT_INTERRUPT;
-            unit->hu_NakTimeoutInt.is_Node.ln_Name = "PCIUSB NakTimeout";
+            unit->hu_NakTimeoutInt.is_Node.ln_Name = strNakTimeoutName;
             unit->hu_NakTimeoutInt.is_Node.ln_Pri  = -16;
             unit->hu_NakTimeoutInt.is_Data = unit;
             unit->hu_NakTimeoutInt.is_Code = (VOID_FUNC)uhwNakTimeoutInt;
@@ -526,7 +533,7 @@ WORD cmdQueryDevice(struct IOUsbHWReq *ioreq,
         count++;
     }
     if((tag = FindTagItem(UHA_Manufacturer, taglist))) {
-        *((STRPTR *) tag->ti_Data) = "The AROS Dev Team";
+        *((STRPTR *) tag->ti_Data) = strArosDevTeam;
         count++;
     }
     if((tag = FindTagItem(UHA_ProductName, taglist))) {
@@ -534,11 +541,11 @@ WORD cmdQueryDevice(struct IOUsbHWReq *ioreq,
         count++;
     }
     if((tag = FindTagItem(UHA_Description, taglist))) {
-        *((STRPTR *) tag->ti_Data) = "xHCI host controller driver for PCI cards";
+        *((STRPTR *) tag->ti_Data) = strXhciDescription;
         count++;
     }
     if((tag = FindTagItem(UHA_Copyright, taglist))) {
-        *((STRPTR *) tag->ti_Data) ="\xA9""2023-2026 The AROS Dev Team";
+        *((STRPTR *) tag->ti_Data) = strXhciCopyright;
         count++;
     }
     if((tag = FindTagItem(UHA_Version, taglist))) {

--- a/rom/usb/pcixhci/xhci_controllerclass.c
+++ b/rom/usb/pcixhci/xhci_controllerclass.c
@@ -23,6 +23,12 @@
 #endif
 #define base (hc->hc_Device)
 
+static const char strXhciInitTaskName[] = "xHCI init";
+static const char strHardwareNamePrefixFmt[] = "PCI USB %u.";
+static const char strHardwareNameMinorUnknown[] = "x";
+static const char strHardwareNameMinorFmt[] = "%u";
+static const char strHardwareNameSuffix[] = " xHCI Host controller";
+
 static BOOL XHCIController__Init(struct PCIController *hc)
 {
     struct XhciHCPrivate *xhcic = NULL;
@@ -46,7 +52,7 @@ static BOOL XHCIController__Init(struct PCIController *hc)
         { TAG_DONE, 0UL },
     };
 
-    if (!xhciOpenTaskTimer(&timerport, &timerreq, "xHCI init")) {
+    if (!xhciOpenTaskTimer(&timerport, &timerreq, strXhciInitTaskName)) {
         return FALSE;
     }
 
@@ -458,12 +464,12 @@ OOP_Object *XHCIController__Root__New(OOP_Class *cl, OOP_Object *o, struct pRoot
         char name_buf[64];
         char *hardware_name = NULL;
 
-        sprintf(name_buf, "PCI USB %u.", hc->hc_USBVersionMajor);
+        sprintf(name_buf, strHardwareNamePrefixFmt, hc->hc_USBVersionMajor);
         if (hc->hc_USBVersionMinor == 0xFF)
-            sprintf(name_buf + 10, "x");
+            sprintf(name_buf + 10, strHardwareNameMinorUnknown);
         else
-            sprintf(name_buf + 10, "%u", hc->hc_USBVersionMinor);
-        sprintf(name_buf + 11, " xHCI Host controller");
+            sprintf(name_buf + 10, strHardwareNameMinorFmt, hc->hc_USBVersionMinor);
+        sprintf(name_buf + 11, strHardwareNameSuffix);
 
         hardware_name = AllocVec(strlen(name_buf) + 1, MEMF_CLEAR);
         if (hardware_name != NULL) {

--- a/rom/usb/pcixhci/xhci_hcd.c
+++ b/rom/usb/pcixhci/xhci_hcd.c
@@ -52,6 +52,7 @@ static char xhciResetIntName[] = "xHCI PCI (pcixhci.device)";
 static char xhciEndpointTimerName[] = "xHCI endpoint";
 static char xhciEventRingTaskNameFmt[] = "usbhw<pcixhci.device/%ld> Event Ring Task";
 static char xhciPortTaskNameFmt[] = "usbhw<pcixhci.device/%ld> Port Task";
+static const char strPoseidonLibraryName[] = "poseidon.library";
 
 static void xhciFreeEndpointContext(struct PCIController *hc,
                                     struct pciusbXHCIDevice *devCtx,
@@ -3419,7 +3420,7 @@ BOOL xhciInit(struct PCIController *hc, struct PCIUnit *hu,
 
 
     struct Library *ps;
-    if ((ps = OpenLibrary("poseidon.library", 5)) == NULL) {
+    if ((ps = OpenLibrary(strPoseidonLibraryName, 5)) == NULL) {
         return FALSE;
     }
     if (!xhcic) {

--- a/rom/usb/pcixhci/xhci_hcport.c
+++ b/rom/usb/pcixhci/xhci_hcport.c
@@ -14,6 +14,8 @@
 #include "uhwcmd.h"
 #include "xhciproto.h"
 
+static const char strXhciPortTaskName[] = "xHCI port task";
+
 #if defined(DEBUG) && defined(XHCI_LONGDEBUGNAK)
 #define XHCI_NAKTOSHIFT         (8)
 #else
@@ -700,7 +702,7 @@ AROS_UFH0(void, xhciPortTask)
 
         timer_ok = xhciOpenTaskTimer(&xhcic->xhc_PortTask.xpt_TimerPort,
                                      &xhcic->xhc_PortTask.xpt_TimerReq,
-                                     "xHCI port task");
+                                     strXhciPortTaskName);
         if (!timer_ok) {
             pciusbError("xHCI", DEBUGWARNCOLOR_SET "%s: unable to open timer.device" DEBUGCOLOR_RESET" \n", __func__);
         }

--- a/rom/usb/pcixhci/xhci_hw.c
+++ b/rom/usb/pcixhci/xhci_hw.c
@@ -29,6 +29,8 @@
 #define LogResBase (base->hd_LogResBase)
 #endif
 
+static const char strXhciEventTaskName[] = "xHCI event task";
+
 #if !defined(PCIUSB_INLINEXHCIOPS)
 void xhciRingDoorbell(struct PCIController *hc, ULONG slot, ULONG value)
 {
@@ -387,7 +389,7 @@ AROS_UFH0(void, xhciEventRingTask)
 
         timer_ok = xhciOpenTaskTimer(&xhcic->xhc_EventTask.xet_TimerPort,
                                      &xhcic->xhc_EventTask.xet_TimerReq,
-                                     "xHCI event task");
+                                     strXhciEventTaskName);
         if (!timer_ok) {
             pciusbError("xHCI", DEBUGWARNCOLOR_SET "%s: unable to open timer.device" DEBUGCOLOR_RESET" \n", __func__);
         }
@@ -444,4 +446,3 @@ task_cleanup:
                        &xhcic->xhc_EventTask.xet_TimerReq);
     AROS_USERFUNC_EXIT
 }
-

--- a/rom/usb/pcixhci/xhciproto.h
+++ b/rom/usb/pcixhci/xhciproto.h
@@ -3,6 +3,8 @@
 
 #include "xhci_hcd.h"
 
+static const char xhciTimerDeviceName[] = "timer.device";
+
 #if !defined(AROS_USE_LOGRES)
 #if defined(DEBUG) && (DEBUG > 1)
 #define XHCI_ENABLEINDEBUG
@@ -35,7 +37,7 @@ static inline BOOL xhciOpenTaskTimer(struct MsgPort **msgport,
     if ((*msgport = CreateMsgPort())) {
         *timerreq = (struct timerequest *)CreateIORequest(*msgport, sizeof(struct timerequest));
         if (*timerreq) {
-            if (!OpenDevice("timer.device", UNIT_MICROHZ, (struct IORequest *)*timerreq, 0)) {
+            if (!OpenDevice(xhciTimerDeviceName, UNIT_MICROHZ, (struct IORequest *)*timerreq, 0)) {
                 (*timerreq)->tr_node.io_Message.mn_Node.ln_Name = (STRPTR)name;
                 (*timerreq)->tr_node.io_Command = TR_ADDREQUEST;
                 return TRUE;


### PR DESCRIPTION
### Motivation
- Reduce duplicated inline string literals and centralize runtime strings that are not purely debug-only for the pcixhci driver.
- Make it easier to maintain and localize device/driver names, timer/device names and task descriptions by exposing them as file-scope constants.

### Description
- Hoisted many constant string literals to file-scope `static const char` globals across pcixhci sources, including `uhwcmd.c`, `pcixhci_arospci.c`, `pcixhci_dev.c`, `xhci_controllerclass.c`, `xhci_hcd.c`, `xhci_hcport.c`, `xhci_hw.c`, and `xhciproto.h`.
- Replaced inline literals with the new globals for timer/device names, hardware and product strings, copyright and manufacturer strings, library names, and task/timer name strings.
- Updated usages such as `OpenDevice`, `OpenLibrary`, `sprintf`, and `pciStrcat` to reference the new constants and adjusted related string-building code accordingly.
- Kept debug-only colors/format macros intact and limited changes to runtime strings (not debug formatting macros).

### Testing
- No automated tests were executed for this change.
- Changes were committed after local edits; no build or unit test was run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dacd58aa88329ba497731e3304a8c)