### PR TITLE
Fix EHCI isochronous scheduling: frame numbering, bandwidth and split masks

### DIFF
--- a/rom/usb/pciusb/ehci/ehcichip.h
+++ b/rom/usb/pciusb/ehci/ehcichip.h
@@ -137,7 +137,7 @@ struct EhciHCPrivate
     UWORD                       ehc_EhciTimeoutShift;
 
     UWORD                       ehc_FrameListSize;
-    UWORD                       ehc_FrameListMask;
+    ULONG                       ehc_FrameListMask;
 
     volatile BOOL               ehc_AsyncAdvanced;
     BOOL                        ehc_64BitCapable;


### PR DESCRIPTION
### Motivation
- Correct incorrect frame-number handling where EHCI uses a 14-bit frame counter but code masked with an 8/variable-sized mask and stored as a too-small type. 
- Prevent isochronous scheduling from overrunning microframe bandwidth by adding accounting and checks. 
- Replace the hardcoded complete-split microframe mask with a selection policy to better support full-speed split transactions. 

### Description
- Widened `ehc_FrameListMask` from `UWORD` to `ULONG` in `ehcichip.h` to safely hold larger periodic list masks. 
- Added `EHCI_FRAME_NUMBER_MASK`, `ehciGetFrameNumber()`, and replaced direct `EHCI_FRAMECOUNT` masking with 14-bit frame handling in `ehci_isoch.c`. 
- Implemented bandwidth accounting helpers `ehciIsoAccumulateBandwidth()` and `ehciIsoBandwidthAvailable()` and a split-mask selector `ehciSelectSplitMasks()` to verify microframe capacity before scheduling. 
- Replaced hardcoded `0x1c` complete-split mask with computed `smask`/`cmask` values and added pre-schedule checks in `ehciStartIsochIO()` so scheduling aborts when bandwidth would be exceeded, and changed the start routine to indicate whether any PTDs were scheduled. 

### Testing
- No automated tests were executed for this change. 
- A manual build/commit was performed to verify the patch applies and compiles in the tree (no runtime tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618819e934832986266c1f901d67b8)