### PR TITLE
Fix isoch TD chaining in OHCI

### DIFF
--- a/rom/usb/pciusb/ohci/ohci_isoch.c
+++ b/rom/usb/pciusb/ohci/ohci_isoch.c
@@ -160,6 +160,7 @@ WORD ohciInitIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
     WRITEMEM32_LE(&oed->oed_HeadPtr, 0);
     WRITEMEM32_LE(&oed->oed_TailPtr, 0);
     oed->oed_FirstTD = NULL;
+    oed->oed_Continue = 0;
     oed->oed_IOReq = &rtn->rtn_IOReq;
 
     rtn->rtn_IOReq.iouh_DriverPrivate1 = oed;
@@ -283,8 +284,7 @@ void ohciStartIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
     UWORD idx;
     UWORD ptdcount = rtn->rtn_PTDCount;
     struct OhciED *intoed;
-    struct OhciTD *lasttd = NULL;
-    ULONG headphys;
+    struct OhciIsoTD *lasttd = NULL;
 
     pciusbOHCIDebug("OHCI", "%s()\n", __func__);
 
@@ -299,18 +299,14 @@ void ohciStartIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
     oed->oed_IOReq = ioreq;
     ioreq->iouh_DriverPrivate2 = rtn;
 
-    headphys = READMEM32_LE(&oed->oed_HeadPtr) & OHCI_PTRMASK;
-    if (headphys && headphys != ohcihcp->ohc_OhciTermTD->otd_Self) {
-        struct OhciTD *scan = (struct OhciTD *)((IPTR)headphys - hc->hc_PCIVirtualAdjust - offsetof(struct OhciTD, otd_Ctrl));
-        ULONG nextphys;
+    lasttd = (struct OhciIsoTD *)oed->oed_Continue;
+    if (!lasttd && oed->oed_FirstTD) {
+        struct OhciIsoTD *scan = (struct OhciIsoTD *)oed->oed_FirstTD;
 
-        while(scan) {
-            nextphys = READMEM32_LE(&scan->otd_NextTD) & OHCI_PTRMASK;
-            if(!nextphys || nextphys == ohcihcp->ohc_OhciTermTD->otd_Self)
-                break;
-            scan = (struct OhciTD *)((IPTR)nextphys - hc->hc_PCIVirtualAdjust - offsetof(struct OhciTD, otd_Ctrl));
-        }
+        while (scan->oitd_Succ)
+            scan = scan->oitd_Succ;
         lasttd = scan;
+        oed->oed_Continue = (IPTR)lasttd;
     }
 
     for(idx = 0; idx < ptdcount; idx++) {
@@ -407,14 +403,16 @@ void ohciStartIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
         SYNC;
 
         if(lasttd) {
-            WRITEMEM32_LE(&lasttd->otd_NextTD, READMEM32_LE(&oitd->oitd_Self));
+            WRITEMEM32_LE(&lasttd->oitd_NextTD, READMEM32_LE(&oitd->oitd_Self));
+            lasttd->oitd_Succ = oitd;
             CacheClearE(lasttd, sizeof(*lasttd), CACRF_ClearD);
         } else {
             WRITEMEM32_LE(&oed->oed_HeadPtr, READMEM32_LE(&oitd->oitd_Self));
             oed->oed_FirstTD = (struct OhciTD *)oitd;
         }
 
-        lasttd = (struct OhciTD *)oitd;
+        lasttd = oitd;
+        oed->oed_Continue = (IPTR)lasttd;
 
         ptd->ptd_Flags |= PTDF_ACTIVE;
     }
@@ -472,7 +470,10 @@ void ohciStopIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
         struct PTDNode *ptd = rtn->rtn_PTDs[idx];
         if(ptd) {
             struct OhciPTDPrivate *ptdpriv = ohciPTDPrivate(ptd);
+            struct OhciIsoTD *oitd = (struct OhciIsoTD *)ptd->ptd_Descriptor;
             ptd->ptd_Flags &= ~(PTDF_ACTIVE|PTDF_BUFFER_VALID);
+            if(oitd)
+                oitd->oitd_Succ = NULL;
             if(ptdpriv->ptd_BounceBuffer &&
                     ptdpriv->ptd_BounceBuffer != ptdpriv->ptd_BufferReq.ubr_Buffer) {
                 usbReleaseBuffer(ptdpriv->ptd_BounceBuffer, ptdpriv->ptd_BufferReq.ubr_Buffer,
@@ -480,6 +481,15 @@ void ohciStopIsochIO(struct PCIController *hc, struct RTIsoNode *rtn)
                 ptdpriv->ptd_BounceBuffer = NULL;
             }
         }
+    }
+
+    if(oed) {
+        WRITEMEM32_LE(&oed->oed_HeadPtr, 0);
+        WRITEMEM32_LE(&oed->oed_TailPtr, 0);
+        oed->oed_FirstTD = NULL;
+        oed->oed_Continue = 0;
+        CacheClearE(&oed->oed_EPCaps, 16, CACRF_ClearD);
+        SYNC;
     }
 }
 


### PR DESCRIPTION
### Motivation

- Ensure newly appended isoch TDs are linked into a software chain so subsequent appends find the true tail instead of rescanning hardware pointers that were never maintained.
- Prevent reuse or loss of stale TDs across stop/start cycles by clearing ED/T D chain state when isoch IO is stopped or initialized.

### Description

- Use a cached software tail stored in `oed->oed_Continue` and change the append tail type to `struct OhciIsoTD *` in `ohciStartIsochIO` so appends use a maintained tail instead of rescanning; initialize it in `ohciInitIsochIO`.
- When appending a new ISO TD set the previous TD's successor (`lasttd->oitd_Succ = oitd`) and set `oitd->oitd_Succ = NULL`, and update `oed->oed_Continue` and `oed->oed_FirstTD` as appropriate.
- In `ohciStopIsochIO` clear per-PTD ISO successor links (`oitd->oitd_Succ = NULL`) and reset ED chain state by writing zero to `oed->oed_HeadPtr`/`oed->oed_TailPtr`, clearing `oed->oed_FirstTD` and `oed->oed_Continue`, and performing cache syncs.
- Keep existing bounce-buffer release and PTD flag clearing while ensuring the software TD chain cannot leave stale pointers that would be reused.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961a40ef8908329af9173e4dae83cee)