### PR TITLE
Expand Thunderbolt enumeration definitions

### DIFF
--- a/compiler/include/hardware/thunderbolt.h
+++ b/compiler/include/hardware/thunderbolt.h
@@ -1,0 +1,34 @@
+#ifndef HARDWARE_THUNDERBOLT_H
+#define HARDWARE_THUNDERBOLT_H
+
+/*
+    Copyright © 2024, The AROS Development Team. All rights reserved.
+    $Id$
+*/
+
+#include <exec/types.h>
+
+#define TBT_MAX_HOPS            6
+#define TBT_MAX_PORTS           64
+#define TBT_ROUTE_HOP_BITS      8
+#define TBT_ROUTE_HOP_MASK      0xff
+#define TBT_ROUTE_HOP_UNUSED    0xff
+
+#define TBT_ROUTE_SHIFT(hop)    ((hop) * TBT_ROUTE_HOP_BITS)
+#define TBT_ROUTE_PORT(route, hop) \
+    (((route) >> TBT_ROUTE_SHIFT(hop)) & TBT_ROUTE_HOP_MASK)
+
+struct TBT_Route
+{
+    UBYTE hops[TBT_MAX_HOPS];
+};
+
+struct TBT_DeviceAddress
+{
+    UWORD domain;
+    UBYTE depth;
+    UBYTE port;
+    UQUAD route;
+};
+
+#endif

--- a/rom/hidds/thunderbolt/include/thunderbolt_hidd.h
+++ b/rom/hidds/thunderbolt/include/thunderbolt_hidd.h
@@ -1,0 +1,74 @@
+#ifndef HIDD_THUNDERBOLT_H
+#define HIDD_THUNDERBOLT_H
+
+/*
+    Copyright © 2024, The AROS Development Team. All rights reserved.
+    $Id$
+*/
+
+#ifndef EXEC_TYPES_H
+#include <exec/types.h>
+#endif
+
+#ifndef HIDD_HIDD_H
+#include <hidd/hidd.h>
+#endif
+
+#ifndef OOP_OOP_H
+#include <oop/oop.h>
+#endif
+
+#ifndef UTILITY_HOOKS_H
+#include <utility/hooks.h>
+#endif
+
+#ifndef UTILITY_TAGITEM_H
+#include <utility/tagitem.h>
+#endif
+
+/* Base Thunderbolt class */
+#define CLID_Hidd_Thunderbolt           "hidd.thunderbolt"
+
+#include <interface/Hidd_Thunderbolt.h>
+
+/* Tags for EnumDevices method */
+enum
+{
+    tHidd_Thunderbolt_VendorID          = TAG_USER,
+    tHidd_Thunderbolt_DeviceID,
+    tHidd_Thunderbolt_RevisionID,
+    tHidd_Thunderbolt_Interface,
+    tHidd_Thunderbolt_Class,
+    tHidd_Thunderbolt_SubClass,
+    tHidd_Thunderbolt_Domain,
+    tHidd_Thunderbolt_Route,
+    tHidd_Thunderbolt_Depth,
+    tHidd_Thunderbolt_Port,
+    tHidd_Thunderbolt_UID,
+    tHidd_Thunderbolt_Driver
+};
+
+/* Thunderbolt device class */
+#define CLID_Hidd_ThunderboltDevice     "hidd.thunderbolt.device"
+#include <interface/Hidd_ThunderboltDevice.h>
+
+#define IS_THUNDERBOLTDEV_ATTR(attr, idx) \
+    (((idx) = (attr) - HiddThunderboltDeviceAttrBase) < num_Hidd_ThunderboltDevice_Attrs)
+
+/* Thunderbolt driver class */
+#define CLID_Hidd_ThunderboltDriver     "hidd.thunderbolt.driver"
+#include <interface/Hidd_ThunderboltDriver.h>
+
+#define IS_THUNDERBOLTDRV_ATTR(attr, idx) \
+    (((idx) = (attr) - HiddThunderboltDriverAttrBase) < num_Hidd_ThunderboltDriver_Attrs)
+
+struct Thunderbolt_RoutingEntry
+{
+    struct MinNode  re_Node;
+    UWORD           re_Domain;
+    ULONG           re_Route;
+    UBYTE           re_Port;
+    UBYTE           re_Depth;
+};
+
+#endif

--- a/rom/hidds/thunderbolt/mmakefile.src
+++ b/rom/hidds/thunderbolt/mmakefile.src
@@ -1,0 +1,12 @@
+include $(SRCDIR)/config/aros.cfg
+
+USER_INCLUDES := -I.
+
+#MM
+includes-copy : $(AROS_INCLUDES)/hidd/thunderbolt.h $(GENINCDIR)/hidd/thunderbolt.h
+
+$(AROS_INCLUDES)/hidd/thunderbolt.h: include/thunderbolt_hidd.h
+	$(CP) $< $(AROS_INCLUDES)/hidd/thunderbolt.h
+
+$(GENINCDIR)/hidd/thunderbolt.h: include/thunderbolt_hidd.h
+	$(CP) $< $(GENINCDIR)/hidd/thunderbolt.h

--- a/rom/hidds/thunderbolt/thunderbolt.conf
+++ b/rom/hidds/thunderbolt/thunderbolt.conf
@@ -1,0 +1,93 @@
+##begin config
+basename        Thunderbolt
+version         1.0
+libbasetype     struct thunderboltbase
+classptr_field  psd.thunderboltClass
+classid         CLID_Hidd_Thunderbolt
+superclass      CLID_HW
+residentpri     88
+oopbase_field   psd.oopBase
+seglist_field   psd.segList
+##end config
+
+##begin cdefprivate
+#include <hidd/thunderbolt.h>
+#include "thunderbolt.h"
+##end cdefprivate
+
+##begin interface
+##begin config
+interfaceid hidd.thunderbolt
+interfacename Hidd_Thunderbolt
+methodstub    HIDD_Thunderbolt
+methodbase    HiddThunderboltBase
+attributebase HiddThunderboltAttrBase
+##end config
+
+##begin attributelist
+##end   attributelist
+
+##begin methodlist
+VOID AddHardwareDriver(OOP_Class *driverClass, struct TagItem *instanceTags)
+BOOL RemHardwareDriver(OOP_Class *driverClass)
+VOID EnumDevices(struct Hook *callback, const struct TagItem *requirements)
+##end   methodlist
+##end interface
+
+##begin interface
+##begin config
+interfaceid   hidd.thunderbolt.driver
+interfacename Hidd_ThunderboltDriver
+methodstub    HIDD_ThunderboltDriver
+methodbase    HiddThunderboltDriverBase
+attributebase HiddThunderboltDriverAttrBase
+##end config
+
+##begin attributelist
+BOOL            DirectConfig   # [..G] DirectConfig shows whether config access is direct
+IPTR            ConfigBase     # [..G] Base address for configuration access
+APTR            RoutingTable   # [..G] Get routing table for that driver, if available
+OOP_Class       *DeviceClass   # [..G] The OOP_Class of devices attached to this driver.
+##end   attributelist
+
+##begin methodlist
+UBYTE ReadConfigByte(OOP_Object *device, UWORD domain, ULONG route, UBYTE port, UWORD reg)
+UWORD ReadConfigWord(OOP_Object *device, UWORD domain, ULONG route, UBYTE port, UWORD reg)
+ULONG ReadConfigLong(OOP_Object *device, UWORD domain, ULONG route, UBYTE port, UWORD reg)
+VOID  WriteConfigByte(OOP_Object *device, UWORD domain, ULONG route, UBYTE port, UWORD reg, UBYTE val)
+VOID  WriteConfigWord(OOP_Object *device, UWORD domain, ULONG route, UBYTE port, UWORD reg, UWORD val)
+VOID  WriteConfigLong(OOP_Object *device, UWORD domain, ULONG route, UBYTE port, UWORD reg, ULONG val)
+BOOL AddInterrupt(OOP_Object *device, struct Interrupt *interrupt)
+VOID RemoveInterrupt(OOP_Object *device, struct Interrupt *interrupt)
+##end  methodlist
+##end  interface
+
+##begin interface
+##begin config
+interfaceid   hidd.thunderbolt.device
+interfacename Hidd_ThunderboltDevice
+methodstub    HIDD_ThunderboltDevice
+methodbase    HiddThunderboltDeviceBase
+attributebase HiddThunderboltDeviceAttrBase
+##end config
+
+##begin attributelist
+OOP_Object *Driver      # [I.G] Hardware Thunderbolt driver that handles this device
+UWORD       Domain      # [I.G] Domain the device is on
+ULONG       Route       # [I.G] Route within the domain
+UBYTE       Port        # [I.G] Port number
+UBYTE       Depth       # [I.G] Route depth
+UQUAD       UID         # [..G] Unique ID for the device (if available)
+UWORD       VendorID    # [..G] VendorID of device as defined in Thunderbolt specs
+UWORD       DeviceID    # [..G] DeviceID
+UWORD       RevisionID  # [..G] RevisionID
+UBYTE       Interface   # [..G]
+UBYTE       Class       # [..G]
+UBYTE       SubClass    # [..G]
+##end   attributelist
+
+##begin methodlist
+CONST_STRPTR Obtain(VOID)
+VOID Release(VOID)
+##end   methodlist
+##end interface

--- a/rom/hidds/thunderbolt/thunderbolt.h
+++ b/rom/hidds/thunderbolt/thunderbolt.h
@@ -1,0 +1,30 @@
+#ifndef _THUNDERBOLT_H
+#define _THUNDERBOLT_H
+
+/*
+    Copyright © 2024, The AROS Development Team. All rights reserved.
+    $Id$
+*/
+
+#include <exec/types.h>
+#include <exec/libraries.h>
+#include <dos/bptr.h>
+
+#include <oop/oop.h>
+
+#include LC_LIBDEFS_FILE
+
+struct thunderbolt_staticdata {
+    struct Library      *oopBase;
+    OOP_Class           *thunderboltClass;
+    BPTR                segList;
+};
+
+struct thunderboltbase {
+    struct Library              LibNode;
+    struct thunderbolt_staticdata psd;
+};
+
+#define BASE(lib)               ((struct thunderboltbase *)(lib))
+
+#endif


### PR DESCRIPTION
### Motivation
- Provide the missing pieces required to enumerate Thunderbolt devices in the way Thunderbolt specs expect by exposing route layout helpers and a compact device address representation.
- Surface per-device attributes required by enumeration and matching, specifically route `Depth` and a device `UID`, so callers/drivers can identify devices uniquely.

### Description
- Add route helper macros and extraction helpers (`TBT_ROUTE_SHIFT`, `TBT_ROUTE_PORT`, `TBT_ROUTE_HOP_BITS`, `TBT_ROUTE_HOP_MASK`) and a `TBT_DeviceAddress` struct in `compiler/include/hardware/thunderbolt.h` to represent domain/route/port/depth for enumeration.
- Add `tHidd_Thunderbolt_Depth` and `tHidd_Thunderbolt_UID` tags to `rom/hidds/thunderbolt/include/thunderbolt_hidd.h` so `EnumDevices` and callers can request/inspect depth and UID attributes.
- Expose the `UID` attribute in the Thunderbolt device interface by adding `UQUAD UID` to `rom/hidds/thunderbolt/thunderbolt.conf` so device objects can carry a unique identifier when available.

### Testing
- No automated tests were run for these changes (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a84f87608329b3b072d81f204138)