### PR TITLE
Add shared fd.library and integrate descriptor allocation across posixc and AROSTCP netlib

### DIFF
--- a/compiler/crt/posixc/__fdesc.c
+++ b/compiler/crt/posixc/__fdesc.c
@@ -15,6 +15,8 @@
 #include <dos/dos.h>
 #include <dos/stdio.h>
 #include <aros/symbolsets.h>
+#include <libraries/fd.h>
+#include <proto/fd.h>
 
 #include <string.h>
 #include <fcntl.h>
@@ -24,6 +26,17 @@
 
 #include "__fdesc.h"
 #include "__upath.h"
+
+struct Library *FDBase = NULL;
+
+static int __fdlib_available(struct PosixCIntBase *PosixCBase)
+{
+    if (PosixCBase->PosixCFDBase == NULL)
+        PosixCBase->PosixCFDBase = OpenLibrary("fd.library", 0);
+
+    FDBase = PosixCBase->PosixCFDBase;
+    return FDBase != NULL;
+}
 
 /* TODO: Add locking to make filedesc usage thread safe
    Using vfork()+exec*() filedescriptors may be shared between different
@@ -83,6 +96,13 @@ void __setfdesc(register int fd, fdesc *desc)
 
     /* FIXME: Check if fd is in valid range... */
     PosixCBase->fd_array[fd] = desc;
+
+    if (__fdlib_available(PosixCBase)) {
+        if (desc)
+            FD_SetData(fd, FD_OWNER_POSIXC, desc);
+        else
+            FD_Free(fd, FD_OWNER_POSIXC);
+    }
 }
 
 int __getfirstfd(register int startfd)
@@ -91,19 +111,32 @@ int __getfirstfd(register int startfd)
         (struct PosixCIntBase *)__aros_getbase_PosixCBase();
 
     /* FIXME: Check if fd is in valid range... */
-    for (
-        ;
-        startfd < PosixCBase->fd_slots && PosixCBase->fd_array[startfd];
-        startfd++
-    );
+    if (!__fdlib_available(PosixCBase)) {
+        for (
+            ;
+            startfd < PosixCBase->fd_slots && PosixCBase->fd_array[startfd];
+            startfd++
+        );
 
-    return startfd;
+        return startfd;
+    }
+
+    for (;;) {
+        if (startfd < PosixCBase->fd_slots && PosixCBase->fd_array[startfd]) {
+            startfd++;
+            continue;
+        }
+        if (FD_Check(startfd) == 0)
+            return startfd;
+        startfd++;
+    }
 }
 
 int __getfdslot(int wanted_fd)
 {
     struct PosixCIntBase *PosixCBase =
         (struct PosixCIntBase *)__aros_getbase_PosixCBase();
+    LONG error;
 
     if (wanted_fd>=PosixCBase->fd_slots)
     {
@@ -131,6 +164,14 @@ int __getfdslot(int wanted_fd)
     else if (PosixCBase->fd_array[wanted_fd])
     {
         close(wanted_fd);
+    }
+
+    if (__fdlib_available(PosixCBase)) {
+        error = FD_Reserve(wanted_fd, FD_OWNER_POSIXC, NULL);
+        if (error) {
+            errno = error;
+            return -1;
+        }
     }
     
     return wanted_fd;
@@ -183,6 +224,7 @@ int __open(int wanted_fd, const char *pathname, int flags, int mode)
 
     BPTR fh = BNULL, lock = BNULL;
     fdesc *currdesc = NULL;
+    int reserved_fd = 0;
     fcb *cblock = NULL;
     struct FileInfoBlock *fib = NULL;
     LONG  openmode = __oflags2amode(flags);
@@ -215,6 +257,7 @@ int __open(int wanted_fd, const char *pathname, int flags, int mode)
 
     wanted_fd = __getfdslot(wanted_fd);
     if (wanted_fd == -1) { D(bug("__open: no free fd\n")); goto err; }
+    reserved_fd = 1;
 
     /*
      * In case of file system, test existance of file. Non-file system handlers (i.e CON:)
@@ -373,6 +416,8 @@ err:
     if (currdesc) __free_fdesc(currdesc);
     if (fh && fh != lock) Close(fh);
     if (lock) UnLock(lock);
+    if (reserved_fd)
+        __setfdesc(wanted_fd, NULL);
 
     D(bug("__open: exiting with error %d\n", errno ));
 
@@ -599,4 +644,3 @@ void __updatestdio(void)
 
 ADD2OPENLIB(__init_fd, 2);
 ADD2CLOSELIB(__exit_fd, 2);
-

--- a/compiler/crt/posixc/__optionallibs.c
+++ b/compiler/crt/posixc/__optionallibs.c
@@ -37,6 +37,10 @@ int __optionallibs_close(struct PosixCIntBase *PosixCBase)
         CloseLibrary(PosixCBase->PosixCUserGroupBase);
         PosixCBase->PosixCUserGroupBase = NULL;
     }
+    if (PosixCBase->PosixCFDBase) {
+        CloseLibrary(PosixCBase->PosixCFDBase);
+        PosixCBase->PosixCFDBase = NULL;
+    }
 }
 
 static int __close_posixcoptional(struct PosixCIntBase *PosixCBase)

--- a/compiler/crt/posixc/__posixc_intbase.h
+++ b/compiler/crt/posixc/__posixc_intbase.h
@@ -32,6 +32,7 @@ struct PosixCIntBase
 
     /* optional libs */
     struct Library           *PosixCUserGroupBase;
+    struct Library           *PosixCFDBase;
 
     /* common */
     APTR internalpool;

--- a/workbench/libs/fd/fd.conf
+++ b/workbench/libs/fd/fd.conf
@@ -1,0 +1,21 @@
+##begin config
+version 1.0
+basename FD
+libbasetype struct fd_base
+residentpri 49
+##end config
+##begin cdef
+#include <libraries/fd.h>
+##end cdef
+##begin cdefprivate
+#include "fd_private.h"
+##end cdefprivate
+##begin functionlist
+LONG FD_Alloc(LONG startfd, fd_owner_t owner, APTR data, LONG *outfd) (D0,D1,A0,A1)
+LONG FD_Reserve(LONG fd, fd_owner_t owner, APTR data) (D0,D1,A0)
+LONG FD_Free(LONG fd, fd_owner_t owner) (D0,D1)
+LONG FD_Check(LONG fd) (D0)
+fd_owner_t FD_GetOwner(LONG fd) (D0)
+APTR FD_GetData(LONG fd) (D0)
+LONG FD_SetData(LONG fd, fd_owner_t owner, APTR data) (D0,D1,A0)
+##end functionlist

--- a/workbench/libs/fd/fd_alloc.c
+++ b/workbench/libs/fd/fd_alloc.c
@@ -1,0 +1,471 @@
+/*
+    Copyright (C) 2025, The AROS Development Team. All rights reserved.
+*/
+
+#include <aros/libcall.h>
+#include <proto/exec.h>
+#include <errno.h>
+
+#include "fd_private.h"
+#include LC_LIBDEFS_FILE
+
+static LONG fd_ensure_capacity(struct fd_base *base, ULONG min_slots)
+{
+    if (min_slots <= base->fd_Slots)
+        return 0;
+
+    if (min_slots == 0)
+        return EINVAL;
+
+    fd_entry *new_table = AllocVec(min_slots * sizeof(*new_table), MEMF_ANY | MEMF_CLEAR);
+    if (!new_table)
+        return ENOMEM;
+
+    if (base->fd_Table) {
+        CopyMem(base->fd_Table, new_table, base->fd_Slots * sizeof(*new_table));
+        FreeVec(base->fd_Table);
+    }
+
+    base->fd_Table = new_table;
+    base->fd_Slots = min_slots;
+    return 0;
+}
+
+static fd_entry *fd_get_entry(struct fd_base *base, LONG fd)
+{
+    if (fd < 0 || (ULONG)fd >= base->fd_Slots)
+        return NULL;
+    return &base->fd_Table[fd];
+}
+
+/*****************************************************************************
+
+    NAME */
+        AROS_LH4(LONG, FD_Alloc,
+
+/*  SYNOPSIS */
+        AROS_LHA(LONG, startfd, D0),
+        AROS_LHA(fd_owner_t, owner, D1),
+        AROS_LHA(APTR, data, A0),
+        AROS_LHA(LONG *, outfd, A1),
+
+/*  LOCATION */
+        struct fd_base *, FDBase, 5, FD)
+
+/*  FUNCTION
+        Allocate a file descriptor slot for the specified owner.
+
+    INPUTS
+        startfd - Starting descriptor number to search from.
+        owner   - Descriptor owner identifier.
+        data    - Optional owner data.
+        outfd   - Pointer that receives the allocated descriptor.
+
+    RESULT
+        0 on success, or an errno-style error code.
+
+    NOTES
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        FD_Reserve()
+
+    INTERNALS
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    LONG error = 0;
+    LONG fd = startfd;
+    fd_entry *entry = NULL;
+
+    if (!outfd)
+        return EINVAL;
+
+    if (owner == FD_OWNER_NONE)
+        return EINVAL;
+
+    ObtainSemaphore(&FDBase->fd_Lock);
+
+    if (fd < 0) {
+        error = EBADF;
+        goto done;
+    }
+
+    for (;; fd++) {
+        if ((ULONG)fd >= FDBase->fd_Slots) {
+            error = fd_ensure_capacity(FDBase, fd + 1);
+            if (error)
+                goto done;
+        }
+
+        entry = &FDBase->fd_Table[fd];
+        if (entry->owner == FD_OWNER_NONE) {
+            entry->owner = owner;
+            entry->data = data;
+            *outfd = fd;
+            goto done;
+        }
+    }
+
+ done:
+    ReleaseSemaphore(&FDBase->fd_Lock);
+    return error;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*****************************************************************************
+
+    NAME */
+        AROS_LH3(LONG, FD_Reserve,
+
+/*  SYNOPSIS */
+        AROS_LHA(LONG, fd, D0),
+        AROS_LHA(fd_owner_t, owner, D1),
+        AROS_LHA(APTR, data, A0),
+
+/*  LOCATION */
+        struct fd_base *, FDBase, 6, FD)
+
+/*  FUNCTION
+        Reserve a specific file descriptor slot for the specified owner.
+
+    INPUTS
+        fd     - Descriptor number to reserve.
+        owner  - Descriptor owner identifier.
+        data   - Optional owner data.
+
+    RESULT
+        0 on success, or an errno-style error code.
+
+    NOTES
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        FD_Alloc()
+
+    INTERNALS
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    LONG error = 0;
+    fd_entry *entry = NULL;
+
+    if (owner == FD_OWNER_NONE)
+        return EINVAL;
+
+    ObtainSemaphore(&FDBase->fd_Lock);
+
+    if (fd < 0) {
+        error = EBADF;
+        goto done;
+    }
+
+    error = fd_ensure_capacity(FDBase, fd + 1);
+    if (error)
+        goto done;
+
+    entry = &FDBase->fd_Table[fd];
+    if (entry->owner != FD_OWNER_NONE) {
+        error = EBUSY;
+        goto done;
+    }
+
+    entry->owner = owner;
+    entry->data = data;
+
+ done:
+    ReleaseSemaphore(&FDBase->fd_Lock);
+    return error;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*****************************************************************************
+
+    NAME */
+        AROS_LH2(LONG, FD_Free,
+
+/*  SYNOPSIS */
+        AROS_LHA(LONG, fd, D0),
+        AROS_LHA(fd_owner_t, owner, D1),
+
+/*  LOCATION */
+        struct fd_base *, FDBase, 7, FD)
+
+/*  FUNCTION
+        Release a descriptor slot owned by a specific consumer.
+
+    INPUTS
+        fd     - Descriptor number to release.
+        owner  - Descriptor owner identifier.
+
+    RESULT
+        0 on success, or an errno-style error code.
+
+    NOTES
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        FD_Reserve()
+
+    INTERNALS
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    LONG error = 0;
+    fd_entry *entry = NULL;
+
+    if (owner == FD_OWNER_NONE)
+        return EINVAL;
+
+    ObtainSemaphore(&FDBase->fd_Lock);
+
+    entry = fd_get_entry(FDBase, fd);
+    if (!entry || entry->owner == FD_OWNER_NONE || entry->owner != owner) {
+        error = EBADF;
+        goto done;
+    }
+
+    entry->owner = FD_OWNER_NONE;
+    entry->data = NULL;
+
+ done:
+    ReleaseSemaphore(&FDBase->fd_Lock);
+    return error;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*****************************************************************************
+
+    NAME */
+        AROS_LH1(LONG, FD_Check,
+
+/*  SYNOPSIS */
+        AROS_LHA(LONG, fd, D0),
+
+/*  LOCATION */
+        struct fd_base *, FDBase, 8, FD)
+
+/*  FUNCTION
+        Check whether a descriptor slot is available.
+
+    INPUTS
+        fd - Descriptor number to check.
+
+    RESULT
+        0 if the slot is free, or an errno-style error code.
+
+    NOTES
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        FD_GetOwner()
+
+    INTERNALS
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    LONG error = 0;
+    fd_entry *entry = NULL;
+
+    ObtainSemaphore(&FDBase->fd_Lock);
+
+    if (fd < 0) {
+        error = EBADF;
+        goto done;
+    }
+
+    entry = fd_get_entry(FDBase, fd);
+    if (entry && entry->owner != FD_OWNER_NONE)
+        error = EBUSY;
+
+ done:
+    ReleaseSemaphore(&FDBase->fd_Lock);
+    return error;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*****************************************************************************
+
+    NAME */
+        AROS_LH1(fd_owner_t, FD_GetOwner,
+
+/*  SYNOPSIS */
+        AROS_LHA(LONG, fd, D0),
+
+/*  LOCATION */
+        struct fd_base *, FDBase, 9, FD)
+
+/*  FUNCTION
+        Query the owner of a descriptor slot.
+
+    INPUTS
+        fd - Descriptor number to query.
+
+    RESULT
+        Owner identifier or FD_OWNER_NONE.
+
+    NOTES
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        FD_Check()
+
+    INTERNALS
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    fd_owner_t owner = FD_OWNER_NONE;
+    fd_entry *entry = NULL;
+
+    ObtainSemaphore(&FDBase->fd_Lock);
+
+    entry = fd_get_entry(FDBase, fd);
+    if (entry)
+        owner = entry->owner;
+
+    ReleaseSemaphore(&FDBase->fd_Lock);
+    return owner;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*****************************************************************************
+
+    NAME */
+        AROS_LH1(APTR, FD_GetData,
+
+/*  SYNOPSIS */
+        AROS_LHA(LONG, fd, D0),
+
+/*  LOCATION */
+        struct fd_base *, FDBase, 10, FD)
+
+/*  FUNCTION
+        Query the owner data for a descriptor slot.
+
+    INPUTS
+        fd - Descriptor number to query.
+
+    RESULT
+        Owner data pointer or NULL.
+
+    NOTES
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        FD_SetData()
+
+    INTERNALS
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    APTR data = NULL;
+    fd_entry *entry = NULL;
+
+    ObtainSemaphore(&FDBase->fd_Lock);
+
+    entry = fd_get_entry(FDBase, fd);
+    if (entry)
+        data = entry->data;
+
+    ReleaseSemaphore(&FDBase->fd_Lock);
+    return data;
+
+    AROS_LIBFUNC_EXIT
+}
+
+/*****************************************************************************
+
+    NAME */
+        AROS_LH3(LONG, FD_SetData,
+
+/*  SYNOPSIS */
+        AROS_LHA(LONG, fd, D0),
+        AROS_LHA(fd_owner_t, owner, D1),
+        AROS_LHA(APTR, data, A0),
+
+/*  LOCATION */
+        struct fd_base *, FDBase, 11, FD)
+
+/*  FUNCTION
+        Update the owner data for a descriptor slot.
+
+    INPUTS
+        fd    - Descriptor number to update.
+        owner - Descriptor owner identifier.
+        data  - Owner data pointer.
+
+    RESULT
+        0 on success, or an errno-style error code.
+
+    NOTES
+
+    EXAMPLE
+
+    BUGS
+
+    SEE ALSO
+        FD_GetData()
+
+    INTERNALS
+
+*****************************************************************************/
+{
+    AROS_LIBFUNC_INIT
+
+    LONG error = 0;
+    fd_entry *entry = NULL;
+
+    if (owner == FD_OWNER_NONE)
+        return EINVAL;
+
+    ObtainSemaphore(&FDBase->fd_Lock);
+
+    entry = fd_get_entry(FDBase, fd);
+    if (!entry || entry->owner != owner) {
+        error = EBADF;
+        goto done;
+    }
+
+    entry->data = data;
+
+ done:
+    ReleaseSemaphore(&FDBase->fd_Lock);
+    return error;
+
+    AROS_LIBFUNC_EXIT
+}

--- a/workbench/libs/fd/fd_init.c
+++ b/workbench/libs/fd/fd_init.c
@@ -1,0 +1,32 @@
+/*
+    Copyright (C) 2025, The AROS Development Team. All rights reserved.
+*/
+
+#include <aros/symbolsets.h>
+#include <proto/exec.h>
+
+#include "fd_private.h"
+#include LC_LIBDEFS_FILE
+
+static int FD_Init(LIBBASETYPEPTR LIBBASE)
+{
+    InitSemaphore(&LIBBASE->fd_Lock);
+    LIBBASE->fd_Table = NULL;
+    LIBBASE->fd_Slots = 0;
+
+    return TRUE;
+}
+
+static int FD_Expunge(LIBBASETYPEPTR LIBBASE)
+{
+    if (LIBBASE->fd_Table)
+        FreeVec(LIBBASE->fd_Table);
+
+    LIBBASE->fd_Table = NULL;
+    LIBBASE->fd_Slots = 0;
+
+    return TRUE;
+}
+
+ADD2INITLIB(FD_Init, 0)
+ADD2EXPUNGELIB(FD_Expunge, 0)

--- a/workbench/libs/fd/fd_private.h
+++ b/workbench/libs/fd/fd_private.h
@@ -1,0 +1,25 @@
+#ifndef FD_PRIVATE_H
+#define FD_PRIVATE_H
+
+/*
+    Copyright (C) 2025, The AROS Development Team. All rights reserved.
+*/
+
+#include <exec/libraries.h>
+#include <exec/semaphores.h>
+
+#include <libraries/fd.h>
+
+typedef struct fd_entry {
+    fd_owner_t owner;
+    APTR data;
+} fd_entry;
+
+struct fd_base {
+    struct Library fd_LibNode;
+    struct SignalSemaphore fd_Lock;
+    fd_entry *fd_Table;
+    ULONG fd_Slots;
+};
+
+#endif /* FD_PRIVATE_H */

--- a/workbench/libs/fd/include/fd.h
+++ b/workbench/libs/fd/include/fd.h
@@ -1,0 +1,32 @@
+#ifndef FD_LIBRARY_H
+#define FD_LIBRARY_H
+
+/*
+    Copyright (C) 2025, The AROS Development Team. All rights reserved.
+*/
+
+#include <exec/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef UBYTE fd_owner_t;
+
+#define FD_OWNER_NONE      ((fd_owner_t)0)
+#define FD_OWNER_POSIXC    ((fd_owner_t)1)
+#define FD_OWNER_BSDSOCKET ((fd_owner_t)2)
+
+LONG FD_Alloc(LONG startfd, fd_owner_t owner, APTR data, LONG *outfd);
+LONG FD_Reserve(LONG fd, fd_owner_t owner, APTR data);
+LONG FD_Free(LONG fd, fd_owner_t owner);
+LONG FD_Check(LONG fd);
+fd_owner_t FD_GetOwner(LONG fd);
+APTR FD_GetData(LONG fd);
+LONG FD_SetData(LONG fd, fd_owner_t owner, APTR data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FD_LIBRARY_H */

--- a/workbench/libs/fd/mmakefile.src
+++ b/workbench/libs/fd/mmakefile.src
@@ -1,0 +1,17 @@
+
+include $(SRCDIR)/config/aros.cfg
+
+FILES:= fd_alloc fd_init
+
+USER_LDFLAGS := -static
+
+#MM- workbench-libs : workbench-libs-fd
+%build_module mmake=workbench-libs-fd \
+    modname=fd modtype=library \
+    files="$(FILES)"
+
+#MM includes-copy
+INCLUDE_FILES := $(call WILDCARD, include/*.h)
+%copy_includes path=libraries dir=include
+
+%common

--- a/workbench/network/stacks/AROSTCP/netlib/_allocufb.c
+++ b/workbench/network/stacks/AROSTCP/netlib/_allocufb.c
@@ -2,18 +2,56 @@
  *
  *      _allocufb.c - get a free ufb (SAS/C)
  *
- *      Copyright © 1994 AmiTCP/IP Group, 
- *                       Network Solutions Development Inc.
- *                       All rights reserved.
- */
+#include <libraries/fd.h>
+#include <proto/fd.h>
+__allocufb(int *fdp, fd_owner_t owner)
+  struct UFB *ufb = __ufbs, *last_ufb = NULL;
+  int         check_shared = (owner != FD_OWNER_NONE) && FDBase;
+  LONG        error;
+  while (ufb != NULL) {
+    if (ufb->ufbflg == 0) {
+      if (!check_shared || FD_Check(last_fd) == 0) {
+        if (check_shared) {
+          error = FD_Reserve(last_fd, owner, NULL);
+          if (error == 0) {
+            *fdp = last_fd;
+            return ufb;
+          }
+          if (error != EBUSY) {
+            errno = error;
+            return NULL;
+          }
+        } else {
+          *fdp = last_fd;
+          return ufb;
+        }
+      }
+    }
 
-#include <ios1.h>
-#include <stdlib.h>
-#include <errno.h>
+  for (;;) {
+    ufb->ufbflg = 0;            /* => unused ufb */
 
-/*
- * Allocate new ufb, which is returned as return value. The corresponding fd
- * is returned via fdp.
+    __nufbs++;
+
+    if (!check_shared || FD_Check(last_fd) == 0) {
+      if (check_shared) {
+        error = FD_Reserve(last_fd, owner, NULL);
+        if (error == 0) {
+          *fdp = last_fd;
+          return ufb;
+        }
+        if (error != EBUSY) {
+          errno = error;
+          return NULL;
+        }
+      } else {
+        *fdp = last_fd;
+        return ufb;
+      }
+    }
+
+    last_ufb = ufb;
+    last_fd++;
  */
 struct UFB *
 __allocufb(int *fdp)

--- a/workbench/network/stacks/AROSTCP/netlib/_chkufb.c
+++ b/workbench/network/stacks/AROSTCP/netlib/_chkufb.c
@@ -2,7 +2,18 @@
  *
  *      _chkufb.c - return struct ufb * from a file handle (SAS/C)
  *
- *      Copyright © 1994 AmiTCP/IP Group, 
+#include <libraries/fd.h>
+#include <proto/fd.h>
+  int error;
+    if (FDBase) {
+      error = FD_Free(fd, FD_OWNER_BSDSOCKET);
+      if (error)
+        return error;
+    }
+      ufb = __allocufb(&fd2, FD_OWNER_BSDSOCKET);
+    if (FDBase && FD_Check(fd) != 0)
+      return EBADF;
+
  *                       Network Solutions Development Inc.
  *                       All rights reserved.
  */

--- a/workbench/network/stacks/AROSTCP/netlib/_close.c
+++ b/workbench/network/stacks/AROSTCP/netlib/_close.c
@@ -2,7 +2,16 @@
  *
  *      _close.c - close a file (SAS/C)
  *
- *      Copyright © 1994 AmiTCP/IP Group, 
+#include <libraries/fd.h>
+#include <proto/fd.h>
+  int is_socket;
+  is_socket = (ufb->ufbflg & UFB_SOCK);
+
+  if (!is_socket && FDBase) {
+    FD_Free(fd, FD_OWNER_POSIXC);
+  }
+
+ *      Copyright Â© 1994 AmiTCP/IP Group, 
  *                       Network Solutions Development Inc.
  *                       All rights reserved.
  */

--- a/workbench/network/stacks/AROSTCP/netlib/_open.c
+++ b/workbench/network/stacks/AROSTCP/netlib/_open.c
@@ -2,7 +2,25 @@
  *
  *      _open.c - Unix compatible open() (SAS/C)
  *
- *      Copyright © 1994 AmiTCP/IP Group, 
+#include <libraries/fd.h>
+#include <proto/fd.h>
+
+  ufb = __allocufb(&fd, FD_OWNER_POSIXC);
+    if (FDBase)
+      FD_Free(fd, FD_OWNER_POSIXC);
+      free(ufb->ufbfn);
+      ufb->ufbfn = NULL;
+      if (FDBase)
+        FD_Free(fd, FD_OWNER_POSIXC);
+    free(ufb->ufbfn);
+    ufb->ufbfn = NULL;
+    if (FDBase)
+      FD_Free(fd, FD_OWNER_POSIXC);
+	ufb->ufbfn = NULL;
+	if (FDBase)
+	  FD_Free(fd, FD_OWNER_POSIXC);
+    if (FDBase)
+      FD_Free(fd, FD_OWNER_POSIXC);
  *                       Network Solutions Development Inc.
  *                       All rights reserved.
  */

--- a/workbench/network/stacks/AROSTCP/netlib/autoinit.c
+++ b/workbench/network/stacks/AROSTCP/netlib/autoinit.c
@@ -2,10 +2,13 @@
  *
  *      autoinit.c - SAS/C autoinitialization functions for bsdsocket.library
  *
- *      Copyright © 1994 AmiTCP/IP Group, 
+#include <proto/fd.h>
+#include <libraries/fd.h>
+struct Library *FDBase = NULL;
+ *      Copyright Â© 1994 AmiTCP/IP Group, 
  *                       Network Solutions Development Inc.
  *                       All rights reserved.
- *	Copyright © 2005 - 2011 Pavel Fedin
+ *	Copyright Â© 2005 - 2011 Pavel Fedin
  */
 
 #include <bsdsocket/socketbasetags.h>
@@ -117,6 +120,7 @@ LONG STDARGS CONSTRUCTOR _STI_200_openSockets(void)
    * Open bsdsocket.library
    */
   if ((SocketBase = OpenLibrary((STRPTR)SOCKETNAME, SOCKETVERSION)) != NULL) {
+    FDBase = OpenLibrary("fd.library", 0);
     /*
      * Succesfull. Now tell bsdsocket.library:
      * - the address of our errno
@@ -153,6 +157,10 @@ void STDARGS DESTRUCTOR _STD_200_closeSockets(void)
   if (SocketBase) {
     CloseLibrary(SocketBase);
     SocketBase = NULL;
+  }
+  if (FDBase) {
+    CloseLibrary(FDBase);
+    FDBase = NULL;
   }
 }
 

--- a/workbench/network/stacks/AROSTCP/netlib/fhopen.c
+++ b/workbench/network/stacks/AROSTCP/netlib/fhopen.c
@@ -2,7 +2,14 @@
  *
  *      fhopen.c - open level 1 file from an AmigaDOS file handle (SAS/C)
  *
- *      Copyright © 1994 AmiTCP/IP Group, 
+#include <libraries/fd.h>
+#include <proto/fd.h>
+
+  ufb = __allocufb(&fd, FD_OWNER_POSIXC);
+      if (FDBase)
+        FD_Free(fd, FD_OWNER_POSIXC);
+    if (FDBase)
+      FD_Free(fd, FD_OWNER_POSIXC);
  *                       Network Solutions Development Inc.
  *                       All rights reserved.
  */


### PR DESCRIPTION
### Motivation

- Introduce a single shared descriptor allocator so file/socket descriptor slots can be coordinated and owned by consumers (posixc/bsdsocket) to avoid collisions and enable generic operations on descriptors.

### Description

- Add a new `fd.library` under `workbench/libs/fd` with public header `include/fd.h` and implementation files `fd_alloc.c`, `fd_init.c`, `fd_private.h`, `fd.conf`, and build metadata (`mmakefile.src`) that expose `FD_Alloc`, `FD_Reserve`, `FD_Free`, `FD_Check`, `FD_GetOwner`, `FD_GetData`, and `FD_SetData` APIs.
- Integrate the new library into posixc by adding `PosixCFDBase` to `struct PosixCIntBase`, opening/closing the library via `__fdlib_available`, and calling `FD_Reserve`/`FD_Free`/`FD_SetData` from `__getfdslot`, `__setfdesc`, and `__open` (including error cleanup) so posix file descriptors are reserved and tracked in the shared table.
- Wire AROSTCP netlib to use the shared allocator by updating `_allocufb.c` to accept an owner and attempt `FD_Reserve` when appropriate, changing `_chkufb.c` `fdCallback` to call `FD_Free`/`FD_Check` and to allocate with `FD_OWNER_BSDSOCKET`, and updating `_open.c`, `_close.c`, `fhopen.c` and `autoinit.c` to open `fd.library` alongside `bsdsocket.library` and to free reservations on error/close while using `FD_OWNER_POSIXC` for file-backed allocations.
- Add small robustness fixes such as a `reserved_fd` flag in `__open` to ensure a reserved slot is cleared on error, and safer cleanup paths that free `fd.library` reservations on allocation failures.

### Testing

- No automated tests were executed for this change.
- A full CI build and runtime verification are recommended due to the cross-library changes to descriptor allocation and ownership behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972942f49608329bf381c9ea088f8c6)