### PR TITLE
Add CDC Ethernet EEM/NCM encapsulation support

### DIFF
--- a/compiler/include/hardware/cdc/cdc_eem.h
+++ b/compiler/include/hardware/cdc/cdc_eem.h
@@ -1,0 +1,10 @@
+#ifndef HARDWARE_CDC_EEM_H
+#define HARDWARE_CDC_EEM_H
+
+#include <exec/types.h>
+
+#define CDC_EEM_HDR_TYPE_COMMAND 0x8000
+#define CDC_EEM_HDR_CRC          0x4000
+#define CDC_EEM_HDR_LEN_MASK     0x3fff
+
+#endif

--- a/compiler/include/hardware/cdc/cdc_ncm.h
+++ b/compiler/include/hardware/cdc/cdc_ncm.h
@@ -1,0 +1,53 @@
+#ifndef HARDWARE_CDC_NCM_H
+#define HARDWARE_CDC_NCM_H
+
+#include <exec/types.h>
+
+#if defined(__GNUC__)
+# pragma pack(1)
+#endif
+
+#define CDC_NCM_FUNC_DESC_SUBTYPE    0x1a
+
+#define CDC_NCM_NTH16_SIGNATURE      0x484d434eUL /* "NCMH" */
+#define CDC_NCM_NDP16_SIGNATURE_NCM0 0x304d434eUL /* "NCM0" */
+#define CDC_NCM_NDP16_SIGNATURE_NCM1 0x314d434eUL /* "NCM1" */
+
+struct UsbCDCNcmFunctionalDesc
+{
+    UBYTE bFunctionLength;
+    UBYTE bDescriptorType;
+    UBYTE bDescriptorSubtype;
+    UWORD bcdNcmVersion;
+    UWORD wMaxSegmentSize;
+    UWORD wNumberMCFilters;
+    UBYTE bNumberPowerFilters;
+};
+
+struct UsbCDCNcmNtb16Header
+{
+    ULONG dwSignature;
+    UWORD wHeaderLength;
+    UWORD wSequence;
+    UWORD wBlockLength;
+    UWORD wNdpIndex;
+};
+
+struct UsbCDCNcmNdp16
+{
+    ULONG dwSignature;
+    UWORD wLength;
+    UWORD wNextNdpIndex;
+};
+
+struct UsbCDCNcmDatagramPointer16
+{
+    UWORD wDatagramIndex;
+    UWORD wDatagramLength;
+};
+
+#if defined(__GNUC__)
+# pragma pack()
+#endif
+
+#endif

--- a/rom/usb/classes/cdceth/cdceth.class.c
+++ b/rom/usb/classes/cdceth/cdceth.class.c
@@ -8,6 +8,7 @@
 #include "debug.h"
 
 #include "cdceth.class.h"
+#include "cdceth_encap.h"
 
 #include <devices/usb_cdc.h>
 
@@ -679,7 +680,7 @@ AROS_UFH0(void, nEthTask)
             if((ncp->ncp_StateFlags & DDF_ONLINE) && (ncp->ncp_ReadPending == NULL))
             {
                 ncp->ncp_ReadPending = ncp->ncp_ReadBuffer[ncp->ncp_ReadBufNum];
-                psdSendPipe(ncp->ncp_EPInPipe, ncp->ncp_ReadPending, ETHER_MAX_LEN);
+                psdSendPipe(ncp->ncp_EPInPipe, ncp->ncp_ReadPending, ncp->ncp_ReadBufSize);
                 ncp->ncp_ReadBufNum ^= 1;
             }
             while((pp = (struct PsdPipe *) GetMsg(ncp->ncp_TaskMsgPort)))
@@ -700,7 +701,7 @@ AROS_UFH0(void, nEthTask)
                         if(ncp->ncp_StateFlags & DDF_ONLINE)
                         {
                             ncp->ncp_ReadPending = ncp->ncp_ReadBuffer[ncp->ncp_ReadBufNum];
-                            psdSendPipe(ncp->ncp_EPInPipe, ncp->ncp_ReadPending, ETHER_MAX_LEN);
+                            psdSendPipe(ncp->ncp_EPInPipe, ncp->ncp_ReadPending, ncp->ncp_ReadBufSize);
                             ncp->ncp_ReadBufNum ^= 1;
                         } else {
                             ncp->ncp_ReadPending = NULL;
@@ -728,7 +729,7 @@ AROS_UFH0(void, nEthTask)
                         } else {
                             KPRINTF(1, ("Pkt %ld received\n", pktlen));
                             DB(dumpmem(pktptr, pktlen));
-                            nReadPacket(ncp, pktptr, pktlen);
+                            cdceth_handle_rx(ncp, pktptr, pktlen);
                         }
                     }
                 }
@@ -1060,16 +1061,21 @@ struct NepClassEth * nAllocEth(void)
                     EA_MaxPktSize, &ncp->ncp_EPOutMaxPktSize,
                     TAG_END);
 
+        cdceth_encap_configure(ncp);
+
         ncp->ncp_ReadPending = NULL;
         ncp->ncp_WritePending = NULL;
-        if(!(ncp->ncp_ReadBuffer[0] = AllocVec(ETHER_MAX_LEN * 4, MEMF_PUBLIC|MEMF_CLEAR)))
         {
-            KPRINTF(1, ("Out of memory for read buffer\n"));
-            break;
+            ULONG bufsize = max(ncp->ncp_ReadBufSize, ncp->ncp_WriteBufSize);
+            if(!(ncp->ncp_ReadBuffer[0] = AllocVec(bufsize * 4, MEMF_PUBLIC|MEMF_CLEAR)))
+            {
+                KPRINTF(1, ("Out of memory for read buffer\n"));
+                break;
+            }
+            ncp->ncp_ReadBuffer[1] = ncp->ncp_ReadBuffer[0] + bufsize;
+            ncp->ncp_WriteBuffer[0] = ncp->ncp_ReadBuffer[1] + bufsize;
+            ncp->ncp_WriteBuffer[1] = ncp->ncp_WriteBuffer[0] + bufsize;
         }
-        ncp->ncp_ReadBuffer[1] = ncp->ncp_ReadBuffer[0] + ETHER_MAX_LEN;
-        ncp->ncp_WriteBuffer[0] = ncp->ncp_ReadBuffer[1] + ETHER_MAX_LEN;
-        ncp->ncp_WriteBuffer[1] = ncp->ncp_WriteBuffer[0] + ETHER_MAX_LEN;
         ncp->ncp_Unit.unit_MsgPort.mp_SigBit = AllocSignal(-1);
         ncp->ncp_Unit.unit_MsgPort.mp_SigTask = thistask;
         ncp->ncp_Unit.unit_MsgPort.mp_Node.ln_Type = NT_MSGPORT;
@@ -1507,7 +1513,7 @@ static void cdceth_complete_write(struct NepClassEth *ncp, LONG ioerr, ULONG act
             if(stats)
             {
                 stats->PacketsSent++;
-                stats->BytesSent += actual ? actual : (ULONG) ioreq->ios2_DataLength;
+                stats->BytesSent += (ULONG) ioreq->ios2_DataLength;
             }
             ncp->ncp_DeviceStats.PacketsSent++;
             ioreq->ios2_Req.io_Error = 0;
@@ -1565,6 +1571,10 @@ BOOL nWritePacket(struct NepClassEth *ncp, struct IOSana2Req *ioreq)
     struct EtherPacketHeader *eph;
     UBYTE *copydest;
     UWORD writelen;
+    ULONG payload_len;
+    ULONG payload_offset = 0;
+    ULONG total_len = 0;
+    ULONG frame_len;
     struct BufMan *bufman;
     UBYTE *buf = ncp->ncp_WriteBuffer[ncp->ncp_WriteBufNum];
 
@@ -1572,26 +1582,40 @@ BOOL nWritePacket(struct NepClassEth *ncp, struct IOSana2Req *ioreq)
     writelen   = ioreq->ios2_DataLength;
     bufman     = ioreq->ios2_BufferManagement;
 
-    eph        = (struct EtherPacketHeader *) buf;
-    copydest   = buf;
+    frame_len = writelen;
+    if(!(ioreq->ios2_Req.io_Flags & SANA2IOF_RAW))
+    {
+        frame_len += sizeof(struct EtherPacketHeader);
+    }
+    payload_len = frame_len < ETHER_MIN_LEN ? ETHER_MIN_LEN : frame_len;
 
-    /* Not a raw packet? */
+    if(!cdceth_prepare_tx(ncp, payload_len, ncp->ncp_WriteBufSize,
+                          &payload_offset, &total_len))
+    {
+        KPRINTF(10, ("writepacket: encapsulation setup failed!\n"));
+
+        /* Trigger any tx, buff or generic error events */
+        nDoEvent(ncp, S2EVENT_ERROR|S2EVENT_TX|S2EVENT_BUFF);
+
+        ioreq->ios2_DataLength   = 0;
+        ioreq->ios2_Req.io_Error = S2ERR_MTU_EXCEEDED;
+        ioreq->ios2_WireError    = S2WERR_GENERIC_ERROR;
+        return FALSE;
+    }
+
+    eph = (struct EtherPacketHeader *) (buf + payload_offset);
+    copydest = buf + payload_offset;
+
     if(!(ioreq->ios2_Req.io_Flags & SANA2IOF_RAW))
     {
         UWORD cnt;
-        KPRINTF(10, ("RAW WRITE!\n"));
-        /* The ethernet header isn't included in the data */
-        /* Build ethernet packet header */
         for(cnt = 0; cnt < ETHER_ADDR_SIZE; cnt++)
         {
             eph->eph_Dest[cnt] = ioreq->ios2_DstAddr[cnt];
             eph->eph_Src[cnt]  = ncp->ncp_MacAddress[cnt];
         }
         eph->eph_Type = AROS_WORD2BE(packettype);
-
-        /* Packet data is at txbuffer */
         copydest += sizeof(struct EtherPacketHeader);
-        writelen += sizeof(struct EtherPacketHeader);
     }
 
     /* Dma not available, fallback to regular copy */
@@ -1611,16 +1635,17 @@ BOOL nWritePacket(struct NepClassEth *ncp, struct IOSana2Req *ioreq)
         return FALSE;
     }
 
-    /* Adjust writelen to legal packet size. */
-    if(writelen < ETHER_MIN_LEN)
+    if(payload_len > frame_len)
     {
-        memset(buf + writelen, 0, ETHER_MIN_LEN - writelen);
-        writelen = ETHER_MIN_LEN;
+        memset(buf + payload_offset + frame_len, 0, payload_len - frame_len);
     }
-    KPRINTF(20, ("PktOut[%ld] %ld\n", ncp->ncp_WriteBufNum, writelen));
+
+    cdceth_finalize_tx(ncp, buf, payload_offset, payload_len, total_len);
+
+    KPRINTF(20, ("PktOut[%ld] %ld\n", ncp->ncp_WriteBufNum, (long) payload_len));
 
     /* Track the padded length so completion can account for bytes sent. */
-    ioreq->ios2_DataLength = writelen;
+    ioreq->ios2_DataLength = payload_len;
     ncp->ncp_WritePending = ioreq;
 
     /*
@@ -1629,7 +1654,7 @@ BOOL nWritePacket(struct NepClassEth *ncp, struct IOSana2Req *ioreq)
      * completions.  If the pipe is already halted, the pending request will be
      * completed with the error when the pipe callback reports it.
      */
-    psdSendPipe(ncp->ncp_EPOutPipe, buf, (ULONG) writelen);
+    psdSendPipe(ncp->ncp_EPOutPipe, buf, (ULONG) total_len);
 
     ncp->ncp_WriteBufNum ^= 1;
 

--- a/rom/usb/classes/cdceth/cdceth.class.h
+++ b/rom/usb/classes/cdceth/cdceth.class.h
@@ -164,6 +164,13 @@
 #define MT_1000BASE_T_FULL_DUP  0x0006
 #define MT_2500BASE_T_FULL_DUP  0x0007
 
+enum cdceth_encap_type
+{
+    CDCETH_ENCAP_ECM = 0,
+    CDCETH_ENCAP_EEM,
+    CDCETH_ENCAP_NCM
+};
+
 struct ClsDevCfg
 {
     ULONG cdc_ChunkID;
@@ -273,6 +280,13 @@ struct NepClassEth
 
     UWORD               ncp_ReadBufNum;   /* Next Read Buffer to use */
     UWORD               ncp_WriteBufNum;  /* Next Write Buffer to use */
+    UBYTE               ncp_EncapType;    /* Encapsulation type */
+    UBYTE               ncp_Pad0;
+    ULONG               ncp_ReadBufSize;  /* Size of each read buffer */
+    ULONG               ncp_WriteBufSize; /* Size of each write buffer */
+    ULONG               ncp_NtbMaxSize;   /* Max NCM NTB size */
+    UWORD               ncp_NcmMaxSegment; /* Max NCM segment size */
+    UWORD               ncp_NcmSeq;       /* NCM sequence number */
 
     struct Sana2DeviceStats ncp_DeviceStats; /* SANA Stats */
     struct Sana2PacketTypeStats *ncp_TypeStats2048; /* IP protocol stats ptr, or NULL */

--- a/rom/usb/classes/cdceth/cdceth_encap.c
+++ b/rom/usb/classes/cdceth/cdceth_encap.c
@@ -1,0 +1,373 @@
+#include "debug.h"
+
+#include "cdceth.class.h"
+#include "cdceth_encap.h"
+
+#include <hardware/cdc/cdc_eem.h>
+#include <hardware/cdc/cdc_ncm.h>
+
+#define CDCETH_EEM_DEFAULT_BUFSIZE  4096
+#define CDCETH_EEM_HEADER_LEN       2
+#define CDCETH_EEM_ALIGN            4
+
+#define CDCETH_NCM_ALIGN            4
+#define CDCETH_NCM_DEFAULT_NTB      16384
+
+static ULONG cdceth_align(ULONG val, ULONG align)
+{
+    return (val + (align - 1)) & ~(align - 1);
+}
+
+BOOL cdceth_encap_configure(struct NepClassEth *ncp)
+{
+    IPTR subcls = CDC_SUBCLASS_ETHERNET;
+
+    ncp->ncp_EncapType = CDCETH_ENCAP_ECM;
+    ncp->ncp_ReadBufSize = ETHER_MAX_LEN;
+    ncp->ncp_WriteBufSize = ETHER_MAX_LEN;
+    ncp->ncp_NcmMaxSegment = ETHER_MAX_LEN;
+    ncp->ncp_NcmSeq = 0;
+    ncp->ncp_NtbMaxSize = ETHER_MAX_LEN;
+
+    if(ncp->ncp_ControlInterface)
+    {
+        psdGetAttrs(PGA_INTERFACE, ncp->ncp_ControlInterface,
+                    IFA_SubClass, &subcls,
+                    TAG_END);
+    }
+
+    switch(subcls)
+    {
+        case CDC_SUBCLASS_EEM:
+            ncp->ncp_EncapType = CDCETH_ENCAP_EEM;
+            ncp->ncp_ReadBufSize = CDCETH_EEM_DEFAULT_BUFSIZE;
+            ncp->ncp_WriteBufSize = CDCETH_EEM_DEFAULT_BUFSIZE;
+            break;
+
+        case CDC_SUBCLASS_NCM:
+        {
+            struct PsdDescriptor *pdd;
+            struct UsbCDCNcmFunctionalDesc *ncm = NULL;
+
+            ncp->ncp_EncapType = CDCETH_ENCAP_NCM;
+            ncp->ncp_NtbMaxSize = CDCETH_NCM_DEFAULT_NTB;
+            ncp->ncp_ReadBufSize = CDCETH_NCM_DEFAULT_NTB;
+            ncp->ncp_WriteBufSize = CDCETH_NCM_DEFAULT_NTB;
+
+            if(ncp->ncp_ControlInterface)
+            {
+                pdd = psdFindDescriptor(ncp->ncp_Device, NULL,
+                                        DDA_Interface, ncp->ncp_ControlInterface,
+                                        DDA_DescriptorType, UDT_CS_INTERFACE,
+                                        DDA_CS_SubType, CDC_NCM_FUNC_DESC_SUBTYPE,
+                                        TAG_END);
+                if(pdd)
+                {
+                    psdGetAttrs(PGA_DESCRIPTOR, pdd,
+                                DDA_DescriptorData, &ncm,
+                                TAG_END);
+                    if(ncm)
+                    {
+                        UWORD seg = AROS_LE2WORD(ncm->wMaxSegmentSize);
+
+                        if(seg)
+                        {
+                            ncp->ncp_NcmMaxSegment = seg;
+                        }
+                    }
+                }
+            }
+            break;
+        }
+
+        case CDC_SUBCLASS_ETHERNET:
+        default:
+            ncp->ncp_EncapType = CDCETH_ENCAP_ECM;
+            break;
+    }
+
+    KPRINTF(5, ("CDC encapsulation configured type %ld rx %lu tx %lu maxseg %u\n",
+                (LONG) ncp->ncp_EncapType,
+                ncp->ncp_ReadBufSize,
+                ncp->ncp_WriteBufSize,
+                (unsigned) ncp->ncp_NcmMaxSegment));
+
+    return(TRUE);
+}
+
+BOOL cdceth_prepare_tx(struct NepClassEth *ncp, ULONG payload_len, ULONG buf_size,
+                       ULONG *payload_offset, ULONG *total_len)
+{
+    ULONG offset = 0;
+    ULONG total = 0;
+
+    if(!payload_offset || !total_len)
+    {
+        return(FALSE);
+    }
+
+    switch(ncp->ncp_EncapType)
+    {
+        case CDCETH_ENCAP_EEM:
+        {
+            if(payload_len > CDC_EEM_HDR_LEN_MASK)
+            {
+                return(FALSE);
+            }
+            offset = CDCETH_EEM_HEADER_LEN;
+            total = cdceth_align(offset + payload_len, CDCETH_EEM_ALIGN);
+            break;
+        }
+
+        case CDCETH_ENCAP_NCM:
+        {
+            ULONG nth_len = sizeof(struct UsbCDCNcmNtb16Header);
+            ULONG ndp_len = sizeof(struct UsbCDCNcmNdp16) +
+                            (sizeof(struct UsbCDCNcmDatagramPointer16) * 2);
+            ULONG ndp_offset = cdceth_align(nth_len, CDCETH_NCM_ALIGN);
+            offset = cdceth_align(ndp_offset + ndp_len, CDCETH_NCM_ALIGN);
+            total = cdceth_align(offset + payload_len, CDCETH_NCM_ALIGN);
+            break;
+        }
+
+        case CDCETH_ENCAP_ECM:
+        default:
+            offset = 0;
+            total = payload_len;
+            break;
+    }
+
+    if((payload_len > 0) && (total > buf_size))
+    {
+        return(FALSE);
+    }
+
+    *payload_offset = offset;
+    *total_len = total;
+    return(TRUE);
+}
+
+void cdceth_finalize_tx(struct NepClassEth *ncp, UBYTE *buf, ULONG payload_offset,
+                        ULONG payload_len, ULONG total_len)
+{
+    switch(ncp->ncp_EncapType)
+    {
+        case CDCETH_ENCAP_EEM:
+        {
+            UWORD header = (UWORD) (payload_len & CDC_EEM_HDR_LEN_MASK);
+            UWORD *hdr = (UWORD *) buf;
+
+            *hdr = AROS_WORD2LE(header);
+            if(total_len > payload_offset + payload_len)
+            {
+                memset(buf + payload_offset + payload_len, 0,
+                       total_len - (payload_offset + payload_len));
+            }
+            break;
+        }
+
+        case CDCETH_ENCAP_NCM:
+        {
+            ULONG nth_len = sizeof(struct UsbCDCNcmNtb16Header);
+            ULONG ndp_len = sizeof(struct UsbCDCNcmNdp16) +
+                            (sizeof(struct UsbCDCNcmDatagramPointer16) * 2);
+            ULONG ndp_offset = cdceth_align(nth_len, CDCETH_NCM_ALIGN);
+            struct UsbCDCNcmNtb16Header *nth = (struct UsbCDCNcmNtb16Header *) buf;
+            struct UsbCDCNcmNdp16 *ndp = (struct UsbCDCNcmNdp16 *) (buf + ndp_offset);
+            struct UsbCDCNcmDatagramPointer16 *dpe =
+                (struct UsbCDCNcmDatagramPointer16 *) ((UBYTE *) ndp + sizeof(*ndp));
+
+            memset(buf, 0, payload_offset);
+
+            nth->dwSignature = AROS_LONG2LE(CDC_NCM_NTH16_SIGNATURE);
+            nth->wHeaderLength = AROS_WORD2LE((UWORD) nth_len);
+            nth->wSequence = AROS_WORD2LE(ncp->ncp_NcmSeq++);
+            nth->wBlockLength = AROS_WORD2LE((UWORD) total_len);
+            nth->wNdpIndex = AROS_WORD2LE((UWORD) ndp_offset);
+
+            ndp->dwSignature = AROS_LONG2LE(CDC_NCM_NDP16_SIGNATURE_NCM0);
+            ndp->wLength = AROS_WORD2LE((UWORD) ndp_len);
+            ndp->wNextNdpIndex = AROS_WORD2LE(0);
+
+            dpe[0].wDatagramIndex = AROS_WORD2LE((UWORD) payload_offset);
+            dpe[0].wDatagramLength = AROS_WORD2LE((UWORD) payload_len);
+            dpe[1].wDatagramIndex = 0;
+            dpe[1].wDatagramLength = 0;
+            break;
+        }
+
+        case CDCETH_ENCAP_ECM:
+        default:
+            break;
+    }
+}
+
+static BOOL cdceth_handle_eem_rx(struct NepClassEth *ncp, UBYTE *pktptr, ULONG pktlen)
+{
+    ULONG offset = 0;
+    BOOL delivered = FALSE;
+
+    while(offset + sizeof(UWORD) <= pktlen)
+    {
+        UWORD header = AROS_LE2WORD(*(UWORD *) (pktptr + offset));
+        UWORD length = (UWORD) (header & CDC_EEM_HDR_LEN_MASK);
+        BOOL is_command = (header & CDC_EEM_HDR_TYPE_COMMAND) != 0;
+        BOOL has_crc = (header & CDC_EEM_HDR_CRC) != 0;
+
+        offset += sizeof(UWORD);
+
+        if(length == 0)
+        {
+            offset = cdceth_align(offset, CDCETH_EEM_ALIGN);
+            continue;
+        }
+
+        if(offset + length > pktlen)
+        {
+            ncp->ncp_DeviceStats.BadData++;
+            break;
+        }
+
+        if(!is_command)
+        {
+            ULONG frame_len = length;
+            if(has_crc && frame_len >= 4)
+            {
+                frame_len -= 4;
+            }
+            if(frame_len >= sizeof(struct EtherPacketHeader))
+            {
+                delivered |= nReadPacket(ncp, pktptr + offset, frame_len);
+            }
+            else
+            {
+                ncp->ncp_DeviceStats.BadData++;
+            }
+        }
+
+        offset += length;
+        offset = cdceth_align(offset, CDCETH_EEM_ALIGN);
+    }
+
+    return delivered;
+}
+
+static BOOL cdceth_handle_ncm_rx(struct NepClassEth *ncp, UBYTE *pktptr, ULONG pktlen)
+{
+    const struct UsbCDCNcmNtb16Header *nth;
+    ULONG block_len;
+    ULONG ndp_index;
+    BOOL delivered = FALSE;
+    int guard = 0;
+
+    if(pktlen < sizeof(*nth))
+    {
+        ncp->ncp_DeviceStats.BadData++;
+        return(FALSE);
+    }
+
+    nth = (const struct UsbCDCNcmNtb16Header *) pktptr;
+    if(AROS_LE2LONG(nth->dwSignature) != CDC_NCM_NTH16_SIGNATURE)
+    {
+        ncp->ncp_DeviceStats.BadData++;
+        return(FALSE);
+    }
+
+    block_len = AROS_LE2WORD(nth->wBlockLength);
+    if(block_len == 0 || block_len > pktlen)
+    {
+        block_len = pktlen;
+    }
+
+    ndp_index = AROS_LE2WORD(nth->wNdpIndex);
+
+    while(ndp_index && guard++ < 4)
+    {
+        const struct UsbCDCNcmNdp16 *ndp;
+        ULONG ndp_length;
+        ULONG ndp_end;
+        ULONG entry_offset;
+        ULONG signature;
+
+        if(ndp_index + sizeof(*ndp) > block_len)
+        {
+            ncp->ncp_DeviceStats.BadData++;
+            break;
+        }
+
+        ndp = (const struct UsbCDCNcmNdp16 *) (pktptr + ndp_index);
+        signature = AROS_LE2LONG(ndp->dwSignature);
+        if(signature != CDC_NCM_NDP16_SIGNATURE_NCM0 &&
+           signature != CDC_NCM_NDP16_SIGNATURE_NCM1)
+        {
+            ncp->ncp_DeviceStats.BadData++;
+            break;
+        }
+
+        ndp_length = AROS_LE2WORD(ndp->wLength);
+        if(ndp_length < sizeof(*ndp))
+        {
+            ncp->ncp_DeviceStats.BadData++;
+            break;
+        }
+
+        ndp_end = ndp_index + ndp_length;
+        if(ndp_end > block_len)
+        {
+            ncp->ncp_DeviceStats.BadData++;
+            break;
+        }
+
+        entry_offset = ndp_index + sizeof(*ndp);
+        while(entry_offset + sizeof(struct UsbCDCNcmDatagramPointer16) <= ndp_end)
+        {
+            const struct UsbCDCNcmDatagramPointer16 *entry;
+            ULONG d_index;
+            ULONG d_len;
+
+            entry = (const struct UsbCDCNcmDatagramPointer16 *) (pktptr + entry_offset);
+            d_index = AROS_LE2WORD(entry->wDatagramIndex);
+            d_len = AROS_LE2WORD(entry->wDatagramLength);
+
+            if(d_index == 0 || d_len == 0)
+            {
+                break;
+            }
+
+            if(d_index + d_len > block_len)
+            {
+                ncp->ncp_DeviceStats.BadData++;
+                break;
+            }
+
+            if(d_len >= sizeof(struct EtherPacketHeader))
+            {
+                delivered |= nReadPacket(ncp, pktptr + d_index, d_len);
+            }
+            else
+            {
+                ncp->ncp_DeviceStats.BadData++;
+            }
+
+            entry_offset += sizeof(struct UsbCDCNcmDatagramPointer16);
+        }
+
+        ndp_index = AROS_LE2WORD(ndp->wNextNdpIndex);
+    }
+
+    return delivered;
+}
+
+BOOL cdceth_handle_rx(struct NepClassEth *ncp, UBYTE *pktptr, ULONG pktlen)
+{
+    switch(ncp->ncp_EncapType)
+    {
+        case CDCETH_ENCAP_EEM:
+            return cdceth_handle_eem_rx(ncp, pktptr, pktlen);
+        case CDCETH_ENCAP_NCM:
+            return cdceth_handle_ncm_rx(ncp, pktptr, pktlen);
+        case CDCETH_ENCAP_ECM:
+        default:
+            return nReadPacket(ncp, pktptr, pktlen);
+    }
+}

--- a/rom/usb/classes/cdceth/cdceth_encap.h
+++ b/rom/usb/classes/cdceth/cdceth_encap.h
@@ -1,0 +1,15 @@
+#ifndef CDCETH_ENCAP_H
+#define CDCETH_ENCAP_H
+
+#include <exec/types.h>
+
+struct NepClassEth;
+
+BOOL cdceth_encap_configure(struct NepClassEth *ncp);
+BOOL cdceth_prepare_tx(struct NepClassEth *ncp, ULONG payload_len, ULONG buf_size,
+                       ULONG *payload_offset, ULONG *total_len);
+void cdceth_finalize_tx(struct NepClassEth *ncp, UBYTE *buf, ULONG payload_offset,
+                        ULONG payload_len, ULONG total_len);
+BOOL cdceth_handle_rx(struct NepClassEth *ncp, UBYTE *pktptr, ULONG pktlen);
+
+#endif

--- a/rom/usb/classes/cdceth/mmakefile.src
+++ b/rom/usb/classes/cdceth/mmakefile.src
@@ -5,7 +5,7 @@ USER_CPPFLAGS := -DMUIMASTER_YES_INLINE_STDARG
 USER_CPPFLAGS += -DDEBUG=1
 USER_LDFLAGS := -static
 
-FILES :=    cdceth.class dev debug
+FILES :=    cdceth.class cdceth_encap dev debug
 
 #MM- kernel-usb-classes-cdceth : kernel-usb-usbclass kernel-usb-poseidon-includes
 


### PR DESCRIPTION
### Motivation
- Implement missing CDC Ethernet encapsulation support so the driver can properly handle ECM (native), EEM and NCM devices by building/parsing EEM frames and NCM NTBs and selecting appropriate buffer sizing and protocol behaviour.
- Skills used: none.

### Description
- Add public CDC protocol headers `compiler/include/hardware/cdc/cdc_eem.h` and `compiler/include/hardware/cdc/cdc_ncm.h` providing EEM/NCM constants and descriptor/NTB structures. 
- Introduce a new encapsulation module `rom/usb/classes/cdceth/cdceth_encap.c/.h` implementing `cdceth_encap_configure()`, `cdceth_prepare_tx()`, `cdceth_finalize_tx()` and `cdceth_handle_rx()` with EEM frame handling and NCM NTB/NDP parsing and NTB construction.
- Extend `rom/usb/classes/cdceth/cdceth.class.h` to add encapsulation state and buffer-size fields (`ncp_EncapType`, `ncp_ReadBufSize`, `ncp_WriteBufSize`, NCM metadata, etc.) used to size buffers and track NCM sequence numbers.
- Wire the encapsulation into the runtime: call `cdceth_encap_configure()` during interface setup, allocate read/write buffers using the encapsulation-chosen sizes, route incoming bulk data through `cdceth_handle_rx()` and wrap outgoing packets via `cdceth_prepare_tx()`/`cdceth_finalize_tx()` from `nWritePacket()`, and adjust transmit accounting in `cdceth_complete_write()`.
- Update the class makefile to build the new encapsulation source.

### Testing
- Automated tests: none were executed for this change.  No build/test run was performed in this patchset.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d31d1151083298b44d6f761883500)