### PR TITLE
Add USB3 stream support for UAS data endpoints

### DIFF
--- a/rom/usb/classes/massstorage/massstorage.class.c
+++ b/rom/usb/classes/massstorage/massstorage.class.c
@@ -1491,6 +1491,120 @@ static BOOL nUasCollectEndpoints(struct NepClassMS *ncm)
     return ncm->ncm_EPCmd && ncm->ncm_EPStatus && ncm->ncm_EPIn && ncm->ncm_EPOut;
 }
 
+static void nUasDisableStreams(struct NepClassMS *ncm)
+{
+    if(ncm->ncm_EPInStream)
+    {
+        psdCloseStream(ncm->ncm_EPInStream);
+        ncm->ncm_EPInStream = NULL;
+    }
+    if(ncm->ncm_EPOutStream)
+    {
+        psdCloseStream(ncm->ncm_EPOutStream);
+        ncm->ncm_EPOutStream = NULL;
+    }
+    if(ncm->ncm_EPIn)
+    {
+        psdSetAttrs(PGA_ENDPOINT, ncm->ncm_EPIn,
+                    EA_StreamBase, 0,
+                    TAG_END);
+    }
+    if(ncm->ncm_EPOut)
+    {
+        psdSetAttrs(PGA_ENDPOINT, ncm->ncm_EPOut,
+                    EA_StreamBase, 0,
+                    TAG_END);
+    }
+    ncm->ncm_UasStreamId = 0;
+}
+
+static void nUasInitStreams(struct NepClassMS *ncm)
+{
+    IPTR maxstreams_in = 0;
+    IPTR maxstreams_out = 0;
+    IPTR maxpkt_in = 0;
+    IPTR maxpkt_out = 0;
+    BOOL use_timeout = ncm->ncm_CDC && ncm->ncm_CDC->cdc_NakTimeout;
+
+    ncm->ncm_UasStreamId = 0;
+    if(!ncm->ncm_EPIn || !ncm->ncm_EPOut)
+    {
+        return;
+    }
+
+    psdGetAttrs(PGA_ENDPOINT, ncm->ncm_EPIn,
+                EA_MaxStreams, &maxstreams_in,
+                EA_MaxPktSize, &maxpkt_in,
+                TAG_END);
+    psdGetAttrs(PGA_ENDPOINT, ncm->ncm_EPOut,
+                EA_MaxStreams, &maxstreams_out,
+                EA_MaxPktSize, &maxpkt_out,
+                TAG_END);
+
+    if(!maxstreams_in || !maxstreams_out)
+    {
+        return;
+    }
+
+    psdSetAttrs(PGA_ENDPOINT, ncm->ncm_EPIn,
+                EA_StreamBase, 1,
+                TAG_END);
+    psdSetAttrs(PGA_ENDPOINT, ncm->ncm_EPOut,
+                EA_StreamBase, 1,
+                TAG_END);
+
+    if(use_timeout)
+    {
+        ncm->ncm_EPOutStream = psdOpenStream(ncm->ncm_EPOut,
+                                            PSA_BufferedWrite, FALSE,
+                                            PSA_NoZeroPktTerm, TRUE,
+                                            PSA_NumPipes, 1,
+                                            PSA_BufferSize, maxpkt_out,
+                                            PSA_NakTimeout, TRUE,
+                                            PSA_NakTimeoutTime, ncm->ncm_CDC->cdc_NakTimeout*100,
+                                            TAG_END);
+    } else {
+        ncm->ncm_EPOutStream = psdOpenStream(ncm->ncm_EPOut,
+                                            PSA_BufferedWrite, FALSE,
+                                            PSA_NoZeroPktTerm, TRUE,
+                                            PSA_NumPipes, 1,
+                                            PSA_BufferSize, maxpkt_out,
+                                            TAG_END);
+    }
+    if(!ncm->ncm_EPOutStream)
+    {
+        nUasDisableStreams(ncm);
+        return;
+    }
+
+    if(use_timeout)
+    {
+        ncm->ncm_EPInStream = psdOpenStream(ncm->ncm_EPIn,
+                                           PSA_BufferedRead, FALSE,
+                                           PSA_ReadAhead, FALSE,
+                                           PSA_NumPipes, 1,
+                                           PSA_BufferSize, maxpkt_in,
+                                           PSA_NakTimeout, TRUE,
+                                           PSA_NakTimeoutTime, ncm->ncm_CDC->cdc_NakTimeout*100,
+                                           TAG_END);
+    } else {
+        ncm->ncm_EPInStream = psdOpenStream(ncm->ncm_EPIn,
+                                           PSA_BufferedRead, FALSE,
+                                           PSA_ReadAhead, FALSE,
+                                           PSA_NumPipes, 1,
+                                           PSA_BufferSize, maxpkt_in,
+                                           TAG_END);
+    }
+    if(!ncm->ncm_EPInStream)
+    {
+        nUasDisableStreams(ncm);
+        return;
+    }
+
+    ncm->ncm_UasStreamId = 1;
+}
+
+
 /* /// "nAllocMS()" */
 struct NepClassMS * GM_UNIQUENAME(nAllocMS)(void)
 {
@@ -1500,6 +1614,9 @@ struct NepClassMS * GM_UNIQUENAME(nAllocMS)(void)
 
     thistask = FindTask(NULL);
     ncm = thistask->tc_UserData;
+    ncm->ncm_EPInStream = NULL;
+    ncm->ncm_EPOutStream = NULL;
+    ncm->ncm_UasStreamId = 0;
     do
     {
         if(!(ncm->ncm_Base = OpenLibrary("poseidon.library", 4)))
@@ -1657,6 +1774,10 @@ struct NepClassMS * GM_UNIQUENAME(nAllocMS)(void)
                                         PPA_AllowRuntPackets, TRUE,
                                         TAG_END);
                         }
+                        if(ncm->ncm_TPType == MS_PROTO_UAS)
+                        {
+                            nUasInitStreams(ncm);
+                        }
                         if(ncm->ncm_EPInt)
                         {
                             if((ncm->ncm_EPIntPipe = psdAllocPipe(ncm->ncm_Device, ncm->ncm_TaskMsgPort, ncm->ncm_EPInt)))
@@ -1716,6 +1837,7 @@ void GM_UNIQUENAME(nFreeMS)(struct NepClassMS *ncm)
     }
     Permit();
 
+    nUasDisableStreams(ncm);
     psdFreePipe(ncm->ncm_EPIntPipe);
     psdFreePipe(ncm->ncm_EPStatusPipe);
     psdFreePipe(ncm->ncm_EPCmdPipe);
@@ -5342,7 +5464,7 @@ AROS_UFH0(void, GM_UNIQUENAME(nGUITask))
     ncm->ncm_App = (APTR) ApplicationObject,
         MUIA_Application_Title      , (IPTR) GM_UNIQUENAME(libname),
         MUIA_Application_Version    , (IPTR) VERSION_STRING,
-        MUIA_Application_Copyright  , (IPTR) "©2002-2009 Chris Hodges",
+        MUIA_Application_Copyright  , (IPTR) "Â©2002-2009 Chris Hodges",
         MUIA_Application_Author     , (IPTR) "Chris Hodges <chrisly@platon42.de>",
         MUIA_Application_Description, (IPTR) "Settings for the massstorage.class",
         MUIA_Application_Base       , (IPTR) "MASSSTORAGE",
@@ -6062,7 +6184,7 @@ AROS_UFH0(void, GM_UNIQUENAME(nGUITask))
                 }
 
                 case ID_ABOUT:
-                    MUI_RequestA(ncm->ncm_App, ncm->ncm_MainWindow, 0, NULL, "Blimey!", VERSION_STRING "\n\nCode for AutoMounting based\non work by Thore Böckelmann.", NULL);
+                    MUI_RequestA(ncm->ncm_App, ncm->ncm_MainWindow, 0, NULL, "Blimey!", VERSION_STRING "\n\nCode for AutoMounting based\non work by Thore BÃ¶ckelmann.", NULL);
                     break;
             }
             if(retid == MUIV_Application_ReturnID_Quit)

--- a/rom/usb/classes/massstorage/massstorage.h
+++ b/rom/usb/classes/massstorage/massstorage.h
@@ -148,12 +148,14 @@ struct NepClassMS
     struct PsdPipe     *ncm_EPOutPipe;    /* Endpoint OUT pipe */
     struct PsdEndpoint *ncm_EPIn;         /* Endpoint IN */
     struct PsdPipe     *ncm_EPInPipe;     /* Endpoint IN pipe */
+    struct PsdPipeStream *ncm_EPInStream; /* UAS IN Endpoint stream */
     struct PsdEndpoint *ncm_EPCmd;        /* UAS Command Endpoint */
     struct PsdPipe     *ncm_EPCmdPipe;    /* UAS Command pipe */
     struct PsdEndpoint *ncm_EPStatus;     /* UAS Status Endpoint */
     struct PsdPipe     *ncm_EPStatusPipe; /* UAS Status pipe */
     struct PsdEndpoint *ncm_EPInt;        /* Optional Endpoint INT */
     struct PsdPipe     *ncm_EPIntPipe;    /* Optional Endpoint INT pipe */
+    struct PsdPipeStream *ncm_EPOutStream;/* UAS OUT Endpoint stream */
     UWORD               ncm_EPOutNum;     /* Endpoint OUT number */
     UWORD               ncm_EPInNum;      /* Endpoint IN number */
     UWORD               ncm_EPCmdNum;     /* UAS Command endpoint number */
@@ -180,6 +182,7 @@ struct NepClassMS
     UWORD               ncm_TPType;       /* Transport type */
     UWORD               ncm_CSType;       /* SCSI Commandset type */
     ULONG               ncm_TagCount;     /* Tag for CBW */
+    UWORD               ncm_UasStreamId;  /* USB3 stream ID in use (0 = none) */
     struct DriveGeometry ncm_Geometry;    /* Drive Geometry */
     ULONG               ncm_GeoChangeCount; /* when did we last obtained the geometry for caching */
     BOOL                ncm_BulkResetBorks; /* Bulk Reset is broken, don't try to use it */

--- a/rom/usb/classes/massstorage/massstorage_uas.c
+++ b/rom/usb/classes/massstorage/massstorage_uas.c
@@ -20,6 +20,47 @@ static void nUasFillLun(UBYTE *lun, UWORD lunnum)
     lun[0] = (UBYTE) (lunnum & 0x3f);
 }
 
+static LONG nUasDoDataTransfer(struct NepClassMS *ncm, UBYTE *data, ULONG data_len,
+                               BOOL read, ULONG *actual)
+{
+    struct PsdPipe *pp;
+    LONG ioerr;
+    LONG actual_len = 0;
+
+    if(ncm->ncm_UasStreamId)
+    {
+        struct PsdPipeStream *stream = read ? ncm->ncm_EPInStream : ncm->ncm_EPOutStream;
+
+        if(stream)
+        {
+            actual_len = read ? psdStreamRead(stream, data, data_len)
+                              : psdStreamWrite(stream, data, data_len);
+            ioerr = psdGetStreamError(stream);
+            if(actual)
+            {
+                *actual = (ULONG) actual_len;
+            }
+            if((ioerr == UHIOERR_OVERFLOW) || (ioerr == UHIOERR_RUNTPACKET))
+            {
+                ioerr = 0;
+            }
+            return ioerr;
+        }
+    }
+
+    pp = read ? ncm->ncm_EPInPipe : ncm->ncm_EPOutPipe;
+    ioerr = psdDoPipe(pp, data, data_len);
+    if(actual)
+    {
+        *actual = psdGetPipeActual(pp);
+    }
+    if((ioerr == UHIOERR_OVERFLOW) || (ioerr == UHIOERR_RUNTPACKET))
+    {
+        ioerr = 0;
+    }
+    return ioerr;
+}
+
 static LONG nUasDoCommand(struct NepClassMS *ncm, const UBYTE *cdb, UWORD cdb_len,
                            UBYTE *data, ULONG data_len, BOOL read,
                            ULONG *actual, UBYTE *status, UBYTE *iu_id,
@@ -31,6 +72,7 @@ static LONG nUasDoCommand(struct NepClassMS *ncm, const UBYTE *cdb, UWORD cdb_le
     ULONG cmdlen;
     ULONG actual_len;
     LONG ioerr;
+    ULONG tag;
 
     if(actual)
     {
@@ -52,7 +94,13 @@ static LONG nUasDoCommand(struct NepClassMS *ncm, const UBYTE *cdb, UWORD cdb_le
     memset(&cmdiu, 0, sizeof(cmdiu));
     cmdiu.iu_Id = UAS_IU_ID_COMMAND;
     cmdiu.iu_TaskAttr = 0;
-    cmdiu.iu_Tag = AROS_LONG2LE(++ncm->ncm_TagCount);
+    if(ncm->ncm_UasStreamId)
+    {
+        tag = ncm->ncm_UasStreamId;
+    } else {
+        tag = ++ncm->ncm_TagCount;
+    }
+    cmdiu.iu_Tag = AROS_LONG2LE(tag);
     nUasFillLun(cmdiu.iu_Lun, ncm->ncm_UnitLUN);
     cmdlen = (cdb_len > 16) ? 16 : cdb_len;
     if(cmdlen)
@@ -68,16 +116,7 @@ static LONG nUasDoCommand(struct NepClassMS *ncm, const UBYTE *cdb, UWORD cdb_le
 
     if(data_len)
     {
-        pp = read ? ncm->ncm_EPInPipe : ncm->ncm_EPOutPipe;
-        ioerr = psdDoPipe(pp, data, data_len);
-        if(actual)
-        {
-            *actual = psdGetPipeActual(pp);
-        }
-        if((ioerr == UHIOERR_OVERFLOW) || (ioerr == UHIOERR_RUNTPACKET))
-        {
-            ioerr = 0;
-        }
+        ioerr = nUasDoDataTransfer(ncm, data, data_len, read, actual);
         if(ioerr)
         {
             return ioerr;


### PR DESCRIPTION
### Motivation
- Enable USB3 stream (SuperSpeed) transfers for UAS devices so large/parallel data transfers can use `psd` stream APIs instead of single pipes.
- Ensure data path and command handling correctly use stream-aware I/O when streams are available.
- Cleanly setup and teardown stream resources alongside existing pipe allocation/cleanup to avoid leaks or incorrect endpoint state.

### Description
- Added stream tracking fields to `struct NepClassMS` (`ncm_EPInStream`, `ncm_EPOutStream`, `ncm_UasStreamId`) in `rom/usb/classes/massstorage/massstorage.h` to track open `PsdPipeStream`s and active stream id.
- Implemented `nUasInitStreams()` and `nUasDisableStreams()` in `massstorage.class.c` to probe `EA_MaxStreams`/`EA_MaxPktSize`, set `EA_StreamBase`, open `psdOpenStream()` for IN/OUT data endpoints (honoring `cdc_NakTimeout`), and to close/reset stream state on teardown.
- Wire `nUasInitStreams()` into allocation path (`nAllocMS`) to attempt stream setup when `ncm_TPType == MS_PROTO_UAS`, and call `nUasDisableStreams()` from `nFreeMS` before freeing pipes.
- Added `nUasDoDataTransfer()` helper in `massstorage_uas.c` that routes data transfers through `psdStreamRead()`/`psdStreamWrite()` when streams are active or falls back to `psdDoPipe()` otherwise, and updated `nUasDoCommand()` to use the helper.
- Adjusted UAS command tag handling so that when streams are in use the code uses the stream id for the IU tag (`iu_Tag`) otherwise it increments the normal `ncm_TagCount` as before.

### Testing
- No automated tests were run on the modified code in this change; only static code inspection and repository checks were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980cc700a188329852c5e5210c69d5b)